### PR TITLE
Improve #1971, especially be robust about system time change

### DIFF
--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/call/DefaultCallSignalingService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/call/DefaultCallSignalingService.kt
@@ -17,6 +17,7 @@
 
 package org.matrix.android.sdk.internal.session.call
 
+import android.os.SystemClock
 import org.matrix.android.sdk.api.MatrixCallback
 import org.matrix.android.sdk.api.extensions.tryThis
 import org.matrix.android.sdk.api.session.call.CallSignalingService
@@ -59,10 +60,10 @@ internal class DefaultCallSignalingService @Inject constructor(
     private val activeCalls = mutableListOf<MxCall>()
 
     private val cachedTurnServerResponse = object {
-
+        // Keep one minute safe to avoid considering the data is valid and then actually it is not when effectively using it.
         private val MIN_TTL = 60
 
-        private val now = { System.currentTimeMillis() / 1000 }
+        private val now = { SystemClock.elapsedRealtime() / 1000 }
 
         private var expiresAt: Long = 0
 


### PR DESCRIPTION
@tzeitlho  this is something I forgot when reviewing #1971 . It's better to not rely on System time, because it can be changed by the user, and even automatically by the system, twice a year or when travelling. For relative/in memory computation, it's safer to use `SystemClock.elapsedRealtime()`