### PR TITLE
Dont set person on sent message notification

### DIFF
--- a/changelog.d/4221.bugfix
+++ b/changelog.d/4221.bugfix
@@ -1,0 +1,1 @@
+Fix conversation notification for sent messages

--- a/vector/src/main/java/im/vector/app/features/notifications/NotificationDrawerManager.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotificationDrawerManager.kt
@@ -325,11 +325,15 @@ class NotificationDrawerManager @Inject constructor(private val context: Context
                     }
                     roomEventGroupInfo.hasNewEvent = roomEventGroupInfo.hasNewEvent || !event.hasBeenDisplayed
 
-                    val senderPerson = Person.Builder()
-                            .setName(event.senderName)
-                            .setIcon(iconLoader.getUserIcon(event.senderAvatarPath))
-                            .setKey(event.senderId)
-                            .build()
+                    val senderPerson = if (event.outGoingMessage) {
+                        null
+                    } else {
+                        Person.Builder()
+                                .setName(event.senderName)
+                                .setIcon(iconLoader.getUserIcon(event.senderAvatarPath))
+                                .setKey(event.senderId)
+                                .build()
+                    }
 
                     if (event.outGoingMessage && event.outGoingMessageFailed) {
                         style.addMessage(stringProvider.getString(R.string.notification_inline_reply_failed), event.timestamp, senderPerson)


### PR DESCRIPTION
Signed-off-by: Alex Baker <alex@beeper.com>

### Pull Request Checklist

<!--
 Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request
 Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked.
 -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
- [x] You've made a self review of your PR
- [x] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)