### PR TITLE
Add API `LoginWizard.loginCustom(data: JsonDict): Session`

### DIFF
--- a/changelog.d/4266.removal
+++ b/changelog.d/4266.removal
@@ -1,0 +1,1 @@
+Add API `LoginWizard.loginCustom(data: JsonDict): Session` to be able to login to a homeserver using arbitrary request content

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/auth/login/LoginWizard.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/auth/login/LoginWizard.kt
@@ -17,6 +17,7 @@
 package org.matrix.android.sdk.api.auth.login
 
 import org.matrix.android.sdk.api.session.Session
+import org.matrix.android.sdk.api.util.JsonDict
 
 /**
  * Set of methods to be able to login to an existing account on a homeserver.
@@ -48,6 +49,12 @@ interface LoginWizard {
      * @return a [Session] if the login is successful
      */
     suspend fun loginWithToken(loginToken: String): Session
+
+    /**
+     * Login to the homeserver by sending a custom JsonDict.
+     * The data should contain at least one entry "type" with a String value.
+     */
+    suspend fun loginCustom(data: JsonDict): Session
 
     /**
      * Ask the homeserver to reset the user password. The password will not be reset until

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/AuthAPI.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/AuthAPI.kt
@@ -121,6 +121,10 @@ internal interface AuthAPI {
     @POST(NetworkConstants.URI_API_PREFIX_PATH_R0 + "login")
     suspend fun login(@Body loginParams: TokenLoginParams): Credentials
 
+    @Headers("CONNECT_TIMEOUT:60000", "READ_TIMEOUT:60000", "WRITE_TIMEOUT:60000")
+    @POST(NetworkConstants.URI_API_PREFIX_PATH_R0 + "login")
+    suspend fun login(@Body loginParams: JsonDict): Credentials
+
     /**
      * Ask the homeserver to reset the password associated with the provided email.
      */

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/login/DefaultLoginWizard.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/login/DefaultLoginWizard.kt
@@ -21,6 +21,7 @@ import org.matrix.android.sdk.api.auth.login.LoginProfileInfo
 import org.matrix.android.sdk.api.auth.login.LoginWizard
 import org.matrix.android.sdk.api.auth.registration.RegisterThreePid
 import org.matrix.android.sdk.api.session.Session
+import org.matrix.android.sdk.api.util.JsonDict
 import org.matrix.android.sdk.internal.auth.AuthAPI
 import org.matrix.android.sdk.internal.auth.PendingSessionStore
 import org.matrix.android.sdk.internal.auth.SessionCreator
@@ -74,6 +75,14 @@ internal class DefaultLoginWizard(
         )
         val credentials = executeRequest(null) {
             authAPI.login(loginParams)
+        }
+
+        return sessionCreator.createSession(credentials, pendingSessionData.homeServerConnectionConfig)
+    }
+
+    override suspend fun loginCustom(data: JsonDict): Session {
+        val credentials = executeRequest(null) {
+            authAPI.login(data)
         }
 
         return sessionCreator.createSession(credentials, pendingSessionData.homeServerConnectionConfig)


### PR DESCRIPTION
To be able to login to a homeserver using arbitrary request content

Fixes #4266 