### PR TITLE
Fixing presence icon anchoring to the middle of the room icon

### DIFF
--- a/changelog.d/5489.bugfix
+++ b/changelog.d/5489.bugfix
@@ -1,0 +1,1 @@
+Fix presence indicator being aligned to the center of the room image

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
@@ -1613,11 +1613,10 @@ class TimelineFragment @Inject constructor(
                 views.includeRoomToolbar.roomToolbarContentView.isClickable = roomSummary.membership == Membership.JOIN
                 views.includeRoomToolbar.roomToolbarTitleView.text = roomSummary.displayName
                 avatarRenderer.render(roomSummary.toMatrixItem(), views.includeRoomToolbar.roomToolbarAvatarImageView)
-                views.includeRoomToolbar.roomToolbarDecorationImageView.render(roomSummary.roomEncryptionTrustLevel)
-                views.includeRoomToolbar.roomToolbarPresenceImageView.render(
-                        roomSummary.isDirect && matrixConfiguration.presenceSyncEnabled,
-                        roomSummary.directUserPresence
-                )
+                val showPresence = roomSummary.isDirect && matrixConfiguration.presenceSyncEnabled
+                views.includeRoomToolbar.roomToolbarPresenceImageView.render(showPresence, roomSummary.directUserPresence)
+                val shieldView = if (showPresence) views.includeRoomToolbar.roomToolbarTitleShield else views.includeRoomToolbar.roomToolbarAvatarShield
+                shieldView.render(roomSummary.roomEncryptionTrustLevel)
                 views.includeRoomToolbar.roomToolbarPublicImageView.isVisible = roomSummary.isPublic && !roomSummary.isDirect
             }
         } else {

--- a/vector/src/main/res/layout/view_room_detail_toolbar.xml
+++ b/vector/src/main/res/layout/view_room_detail_toolbar.xml
@@ -19,15 +19,6 @@
         app:layout_constraintTop_toTopOf="parent"
         tools:src="@sample/room_round_avatars" />
 
-    <im.vector.app.core.ui.views.ShieldImageView
-        android:id="@+id/roomToolbarDecorationImageView"
-        android:layout_width="11dp"
-        android:layout_height="13dp"
-        app:layout_constraintCircle="@id/roomToolbarAvatarImageView"
-        app:layout_constraintCircleAngle="120"
-        app:layout_constraintCircleRadius="18dp"
-        tools:ignore="MissingConstraints" />
-
     <im.vector.app.core.ui.views.PresenceStateImageView
         android:id="@+id/roomToolbarPresenceImageView"
         android:layout_width="11dp"
@@ -36,11 +27,9 @@
         android:padding="2dp"
         android:visibility="gone"
         app:layout_constraintCircle="@id/roomToolbarAvatarImageView"
-        app:layout_constraintCircleAngle="0"
-        app:layout_constraintCircleRadius="0dp"
+        app:layout_constraintCircleAngle="135"
+        app:layout_constraintCircleRadius="20dp"
         tools:ignore="MissingConstraints"
-        tools:layout_constraintCircleAngle="60"
-        tools:layout_constraintCircleRadius="18dp"
         tools:src="@drawable/ic_presence_offline"
         tools:visibility="visible" />
 
@@ -59,27 +48,50 @@
         tools:ignore="MissingConstraints"
         tools:visibility="invisible" />
 
+    <im.vector.app.core.ui.views.ShieldImageView
+        android:id="@+id/roomToolbarAvatarShield"
+        android:layout_width="11dp"
+        android:layout_height="13dp"
+        app:layout_constraintCircle="@id/roomToolbarAvatarImageView"
+        app:layout_constraintCircleAngle="120"
+        app:layout_constraintCircleRadius="18dp"
+        android:visibility="gone"
+        tools:visibility="gone"
+        tools:ignore="MissingConstraints" />
+
     <androidx.constraintlayout.widget.Barrier
         android:id="@+id/imageGroupBarrier"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:barrierDirection="end"
-        app:constraint_referenced_ids="roomToolbarDecorationImageView,roomToolbarAvatarImageView,roomToolbarPresenceImageView,roomToolbarPublicImageView" />
+        app:constraint_referenced_ids="roomToolbarAvatarImageView,roomToolbarAvatarShield,roomToolbarPresenceImageView,roomToolbarPublicImageView" />
+
+    <im.vector.app.core.ui.views.ShieldImageView
+        android:id="@+id/roomToolbarTitleShield"
+        android:layout_width="11dp"
+        android:layout_height="13dp"
+        android:layout_marginStart="2dp"
+        android:layout_marginTop="2dp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@id/roomToolbarTitleView"
+        app:layout_constraintEnd_toStartOf="@id/roomToolbarTitleView"
+        app:layout_constraintStart_toEndOf="@id/imageGroupBarrier"
+        app:layout_constraintTop_toTopOf="@id/roomToolbarTitleView"
+        tools:ignore="MissingConstraints" />
 
     <TextView
         android:id="@+id/roomToolbarTitleView"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="12dp"
+        android:layout_marginStart="2dp"
         android:layout_marginEnd="8dp"
         android:ellipsize="end"
         android:maxLines="1"
-        android:textAlignment="viewStart"
         android:textAppearance="@style/TextAppearance.Vector.Widget.ActionBarTitle"
         app:layout_constraintBottom_toBottomOf="@id/roomToolbarAvatarImageView"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toEndOf="@id/imageGroupBarrier"
+        app:layout_constraintStart_toEndOf="@id/roomToolbarTitleShield"
         app:layout_constraintTop_toTopOf="@id/roomToolbarAvatarImageView"
         app:layout_constraintVertical_chainStyle="packed"
         app:layout_goneMarginStart="7dp"


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Introduces a second shield view, anchored to the room title for use when the presence indicator is present.

## Motivation and context
 
Fixes #5489, wrong presence indicator alignment.

This is an intermediate bug fix for the presence indicator anchoring to the center of the room icon. Ideally we'll have a second iteration once design is available :crossed_fingers: 

## Screenshots / GIFs

| | BEFORE | AFTER |
| --- | --- |  --- |
| NO PRESENCE |![Screenshot_20220322_132042](https://user-images.githubusercontent.com/1848238/159491152-4edbe4ad-80f4-4acd-ab5d-f0e4f5a5de49.png)|![Screenshot_20220322_123446](https://user-images.githubusercontent.com/1848238/159489186-7e753d27-4763-4c6a-9449-cbc233c0a29d.png)
| WITH PRESENCE |![Screenshot_20220322_132001](https://user-images.githubusercontent.com/1848238/159491155-aaacda33-b7df-4b29-a128-98df2c2007e9.png)|![Screenshot_20220322_123522](https://user-images.githubusercontent.com/1848238/159489182-4f3dae6b-6e49-4937-8878-8c37a9f33140.png)

## Tests

- Open a room with a user who has presence enabled
- See the top app bar has a misaligned presence indicator 

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 10
