### PR TITLE
create fallback turn server option

### DIFF
--- a/changelog.d/2329.feature
+++ b/changelog.d/2329.feature
@@ -1,0 +1,1 @@
+Add setting to enable using turn.matrix.org as a fallback measure.

--- a/vector-config/src/main/res/values/config.xml
+++ b/vector-config/src/main/res/values/config.xml
@@ -5,6 +5,7 @@
 
     <!-- server urls -->
     <string name="matrix_org_server_url" translatable="false">https://matrix.org</string>
+    <string name="fallback_stun_server_url" translatable="false">turn.matrix.org</string>
 
     <!-- Rageshake configuration -->
     <string name="bug_report_url" translatable="false">https://riot.im/bugreports/submit</string>

--- a/vector/src/main/java/im/vector/app/features/call/webrtc/WebRtcCallManager.kt
+++ b/vector/src/main/java/im/vector/app/features/call/webrtc/WebRtcCallManager.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import im.vector.app.ActiveSessionDataSource
 import im.vector.app.BuildConfig
+import im.vector.app.core.resources.StringProvider
 import im.vector.app.core.services.CallService
 import im.vector.app.features.analytics.AnalyticsTracker
 import im.vector.app.features.analytics.plan.CallEnded
@@ -32,6 +33,7 @@ import im.vector.app.features.call.lookup.CallUserMapper
 import im.vector.app.features.call.utils.EglUtils
 import im.vector.app.features.call.vectorCallService
 import im.vector.app.features.session.coroutineScope
+import im.vector.app.features.settings.VectorPreferences
 import im.vector.app.push.fcm.FcmHelper
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.asCoroutineDispatcher
@@ -72,7 +74,9 @@ private val loggerTag = LoggerTag("WebRtcCallManager", LoggerTag.VOIP)
 class WebRtcCallManager @Inject constructor(
         private val context: Context,
         private val activeSessionDataSource: ActiveSessionDataSource,
-        private val analyticsTracker: AnalyticsTracker
+        private val analyticsTracker: AnalyticsTracker,
+        private var vectorPreferences: VectorPreferences,
+        private val stringProvider: StringProvider
 ) : CallListener,
         DefaultLifecycleObserver {
 
@@ -332,7 +336,9 @@ class WebRtcCallManager @Inject constructor(
                 },
                 sessionProvider = { currentSession },
                 onCallBecomeActive = this::onCallActive,
-                onCallEnded = this::onCallEnded
+                onCallEnded = this::onCallEnded,
+                vectorPreferences = vectorPreferences,
+                stringProvider = stringProvider
         )
         advertisedCalls.add(mxCall.callId)
         callsByCallId[mxCall.callId] = webRtcCall

--- a/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
@@ -138,6 +138,7 @@ class VectorPreferences @Inject constructor(private val context: Context) {
 
         // Calls
         const val SETTINGS_CALL_PREVENT_ACCIDENTAL_CALL_KEY = "SETTINGS_CALL_PREVENT_ACCIDENTAL_CALL_KEY"
+        const val SETTINGS_CALL_USE_FALLBACK_CALL_ASSIST_SERVER_KEY = "SETTINGS_CALL_USE_FALLBACK_CALL_ASSIST_SERVER_KEY"
         const val SETTINGS_CALL_RINGTONE_USE_RIOT_PREFERENCE_KEY = "SETTINGS_CALL_RINGTONE_USE_RIOT_PREFERENCE_KEY"
         const val SETTINGS_CALL_RINGTONE_URI_PREFERENCE_KEY = "SETTINGS_CALL_RINGTONE_URI_PREFERENCE_KEY"
 
@@ -719,6 +720,13 @@ class VectorPreferences @Inject constructor(private val context: Context) {
      */
     fun preventAccidentalCall(): Boolean {
         return defaultPrefs.getBoolean(SETTINGS_CALL_PREVENT_ACCIDENTAL_CALL_KEY, false)
+    }
+
+    /**
+     * Tells if turn.matrix should be used during calls as a fallback
+     */
+    fun useFallbackTurnServer(): Boolean {
+        return defaultPrefs.getBoolean(SETTINGS_CALL_USE_FALLBACK_CALL_ASSIST_SERVER_KEY, false)
     }
 
     /**

--- a/vector/src/main/java/im/vector/app/features/settings/VectorSettingsVoiceVideoFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorSettingsVoiceVideoFragment.kt
@@ -43,6 +43,9 @@ class VectorSettingsVoiceVideoFragment : VectorSettingsBaseFragment() {
     private val mCallRingtonePreference by lazy {
         findPreference<VectorPreference>(VectorPreferences.SETTINGS_CALL_RINGTONE_URI_PREFERENCE_KEY)!!
     }
+    private val useDefaultStunPreference by lazy {
+        findPreference<SwitchPreference>(VectorPreferences.SETTINGS_CALL_USE_FALLBACK_CALL_ASSIST_SERVER_KEY)!!
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -54,6 +57,11 @@ class VectorSettingsVoiceVideoFragment : VectorSettingsBaseFragment() {
         mUseRiotCallRingtonePreference.onPreferenceClickListener = Preference.OnPreferenceClickListener {
             activity?.let { setUseRiotDefaultRingtone(it, mUseRiotCallRingtonePreference.isChecked) }
             false
+        }
+
+        useDefaultStunPreference.let {
+            val stun = getString(R.string.fallback_stun_server_url)
+            it.summary = getString(R.string.settings_call_ringtone_use_default_stun_summary, stun)
         }
 
         mCallRingtonePreference.let {

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -548,6 +548,8 @@
     <string name="settings_call_category">Calls</string>
     <string name="settings_call_show_confirmation_dialog_title">Prevent accidental call</string>
     <string name="settings_call_show_confirmation_dialog_summary">Ask for confirmation before starting a call</string>
+    <string name="settings_call_ringtone_use_default_stun_title">Allow fallback call assist server</string>
+    <string name="settings_call_ringtone_use_default_stun_summary">Will use %s as assist when your homeserver does not offer one (your IP address will be seen by the stun server during a call)</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
     <string name="settings_call_ringtone_use_app_ringtone">Use default ${app_name} ringtone for incoming calls</string>
     <string name="settings_call_ringtone_title">Incoming call ringtone</string>

--- a/vector/src/main/res/xml/vector_settings_voice_video.xml
+++ b/vector/src/main/res/xml/vector_settings_voice_video.xml
@@ -11,6 +11,12 @@
             android:title="@string/settings_call_show_confirmation_dialog_title" />
 
         <im.vector.app.core.preference.VectorSwitchPreference
+            android:defaultValue="false"
+            android:key="SETTINGS_CALL_USE_FALLBACK_CALL_ASSIST_SERVER_KEY"
+            android:summary="@string/settings_call_ringtone_use_default_stun_summary"
+            android:title="@string/settings_call_ringtone_use_default_stun_title" />
+
+        <im.vector.app.core.preference.VectorSwitchPreference
             android:defaultValue="true"
             android:disableDependentsState="true"
             android:key="SETTINGS_CALL_RINGTONE_USE_RIOT_PREFERENCE_KEY"


### PR DESCRIPTION
Fixes #2329 
Fixes #3063

# PR Moved from https://github.com/vector-im/element-android/pull/4391

## Screenshot
You need to enable the fallback option in `Settings > Voice & Video` to use this feature.
![Screenshot_20211106-215730_Element dbg.png](https://user-images.githubusercontent.com/52425971/140624995-a3804042-6519-414a-9dc8-efe6c3e0f639.png)