### PR TITLE
Fix non-emoji reaction text colour on dark theme

### DIFF
--- a/changelog.d/6397.bugfix
+++ b/changelog.d/6397.bugfix
@@ -1,0 +1,1 @@
+Fix non-emoji reaction text colour on dark theme

--- a/library/ui-styles/src/main/res/values/colors.xml
+++ b/library/ui-styles/src/main/res/values/colors.xml
@@ -21,8 +21,6 @@
     <color name="vctr_notice_secondary_alpha12">#1E61708B</color>
 
     <!-- Other useful color -->
-    <!-- Emoji text has to use a black text color -->
-    <color name="emoji_color">@android:color/black</color>
     <color name="join_conference_animated_color">#0BAC7E</color>
 
     <color name="half_transparent_status_bar">#80000000</color>

--- a/vector/src/debug/res/layout/item_sas_emoji.xml
+++ b/vector/src/debug/res/layout/item_sas_emoji.xml
@@ -27,7 +27,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="8dp"
-        android:textColor="@color/emoji_color"
+        android:textColor="?vctr_content_primary"
         tools:text="🔧" />
 
     <LinearLayout

--- a/vector/src/main/res/layout/item_autocomplete_emoji.xml
+++ b/vector/src/main/res/layout/item_autocomplete_emoji.xml
@@ -15,7 +15,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
-        android:textColor="@color/emoji_color"
+        android:textColor="?vctr_content_primary"
         tools:ignore="SpUsage"
         tools:text="@sample/reactions.json/data/reaction" />
 

--- a/vector/src/main/res/layout/item_emoji_result.xml
+++ b/vector/src/main/res/layout/item_emoji_result.xml
@@ -18,7 +18,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginEnd="8dp"
-        android:textColor="@color/emoji_color"
+        android:textColor="?vctr_content_primary"
         tools:ignore="SpUsage"
         tools:text="@sample/reactions.json/data/reaction" />
 

--- a/vector/src/main/res/layout/item_emoji_verif.xml
+++ b/vector/src/main/res/layout/item_emoji_verif.xml
@@ -14,7 +14,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
-        android:textColor="@color/emoji_color"
+        android:textColor="?vctr_content_primary"
         android:textSize="40dp"
         tools:ignore="SpUsage"
         tools:text="🌵"

--- a/vector/src/main/res/layout/item_simple_reaction_info.xml
+++ b/vector/src/main/res/layout/item_simple_reaction_info.xml
@@ -19,7 +19,7 @@
         android:layout_marginEnd="8dp"
         android:gravity="center"
         android:lines="1"
-        android:textColor="@color/emoji_color"
+        android:textColor="?vctr_content_primary"
         tools:text="@sample/reactions.json/data/reaction" />
 
     <TextView

--- a/vector/src/main/res/layout/reaction_button.xml
+++ b/vector/src/main/res/layout/reaction_button.xml
@@ -23,7 +23,7 @@
         android:gravity="center"
         android:maxEms="10"
         android:singleLine="true"
-        android:textColor="@color/emoji_color"
+        android:textColor="?vctr_content_primary"
         tools:text="* Party Parrot Again * 👀" />
 
     <TextView


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- Bugfix

## Content
This fix is taken from the SchildiChat code, with testing. https://github.com/SchildiChat/SchildiChat-android/commit/004a51646b2acd18f37d7bfbf3ff0a22f43a60be

SpritCroc successfully identified why the text colour was wrong, and has the correct fix. They are concerned about emojis being faded if Element uses a transparent main text colour. Maybe that was the case in the past, but the text is opaque now, so this code fully works.

## Motivation and context

fixes #6351, fixes #6052

## Screenshots / GIFs

https://cadence.moe/i/e34f69.png

## Tests

I looked at the interface with several coloured and text reactions to make sure my change didn't have unintended consequences.

I only checked the chat interface and reactions interface. I didn't check the verification interface since I don't know how to get into it again.

## Tested devices

- Physical: OnePlus 5T, LineageOS 18.1 (Android 11)

## Checklist

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- Accessibility has been taken into account - N/A
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- If you have modified the screen flow, or added new screens to the application - N/A

Signed-off-by: Cadence Ember <cloudrac3r@vivaldi.net>