### PR TITLE
Refactored location sharing timeline items to use the mapserver configured by the wellknown file

### DIFF
--- a/changelog.d/7852.feature
+++ b/changelog.d/7852.feature
@@ -1,0 +1,1 @@
+Refactored location sharing timeline items to use the mapserver configured by the wellknown file

--- a/library/ui-strings/src/main/res/values/donottranslate.xml
+++ b/library/ui-strings/src/main/res/values/donottranslate.xml
@@ -10,6 +10,4 @@
     <!-- onboarding english only word play -->
     <string name="cut_the_slack_from_teams" translatable="false">Cut the slack from teams.</string>
 
-    <!--  WIP -->
-    <string name="location_map_view_copyright" translatable="false">© MapTiler © OpenStreetMap contributors</string>
 </resources>

--- a/vector-config/src/main/java/im/vector/app/config/Config.kt
+++ b/vector-config/src/main/java/im/vector/app/config/Config.kt
@@ -41,6 +41,7 @@ object Config {
 
     const val ENABLE_LOCATION_SHARING = true
     const val LOCATION_MAP_TILER_KEY = "fU3vlMsMn4Jb6dnEIFsx"
+    const val ENABLE_LOCATION_SHARING_MAPSERVER_FALLBACK = true
 
     /**
      * The maximum length of voice messages in milliseconds.

--- a/vector/src/main/java/im/vector/app/core/di/ConfigurationModule.kt
+++ b/vector/src/main/java/im/vector/app/core/di/ConfigurationModule.kt
@@ -73,6 +73,7 @@ object ConfigurationModule {
     @Provides
     fun providesLocationSharingConfig() = LocationSharingConfig(
             mapTilerKey = Config.LOCATION_MAP_TILER_KEY,
+            isMapTilerFallbackEnabled = Config.ENABLE_LOCATION_SHARING_MAPSERVER_FALLBACK
     )
 
     @Provides

--- a/vector/src/main/java/im/vector/app/core/epoxy/bottomsheet/BottomSheetMessagePreviewItem.kt
+++ b/vector/src/main/java/im/vector/app/core/epoxy/bottomsheet/BottomSheetMessagePreviewItem.kt
@@ -36,6 +36,7 @@ import im.vector.app.features.home.AvatarRenderer
 import im.vector.app.features.home.room.detail.timeline.action.LocationUiData
 import im.vector.app.features.home.room.detail.timeline.item.BindingOptions
 import im.vector.app.features.home.room.detail.timeline.tools.findPillsAndProcess
+import im.vector.app.features.location.INITIAL_MAP_ZOOM_IN_TIMELINE
 import im.vector.app.features.location.zoomToLocation
 import im.vector.app.features.media.ImageContentRenderer
 import im.vector.lib.core.utils.epoxy.charsequence.EpoxyCharSequence
@@ -102,7 +103,7 @@ abstract class BottomSheetMessagePreviewItem : VectorEpoxyModel<BottomSheetMessa
             holder.staticMapView.getMapAsync { mapbox ->
                 mapbox.setStyle(safeLocationUiData.locationUrl)
                 safeLocationUiData.locationData?.let {
-                    mapbox.zoomToLocation(it, animate = false)
+                    mapbox.zoomToLocation(it, false, INITIAL_MAP_ZOOM_IN_TIMELINE)
                 }
                 mapbox.uiSettings.setAllGesturesEnabled(false)
             }

--- a/vector/src/main/java/im/vector/app/core/epoxy/bottomsheet/BottomSheetMessagePreviewItem.kt
+++ b/vector/src/main/java/im/vector/app/core/epoxy/bottomsheet/BottomSheetMessagePreviewItem.kt
@@ -23,7 +23,7 @@ import android.widget.TextView
 import androidx.core.view.isVisible
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
-import com.bumptech.glide.request.RequestOptions
+import com.mapbox.mapboxsdk.maps.MapView
 import im.vector.app.R
 import im.vector.app.core.epoxy.ClickListener
 import im.vector.app.core.epoxy.VectorEpoxyHolder
@@ -36,6 +36,7 @@ import im.vector.app.features.home.AvatarRenderer
 import im.vector.app.features.home.room.detail.timeline.action.LocationUiData
 import im.vector.app.features.home.room.detail.timeline.item.BindingOptions
 import im.vector.app.features.home.room.detail.timeline.tools.findPillsAndProcess
+import im.vector.app.features.location.zoomToLocation
 import im.vector.app.features.media.ImageContentRenderer
 import im.vector.lib.core.utils.epoxy.charsequence.EpoxyCharSequence
 import org.matrix.android.sdk.api.util.MatrixItem
@@ -98,10 +99,13 @@ abstract class BottomSheetMessagePreviewItem : VectorEpoxyModel<BottomSheetMessa
         holder.body.isVisible = locationUiData == null
         holder.mapViewContainer.isVisible = locationUiData != null
         locationUiData?.let { safeLocationUiData ->
-            GlideApp.with(holder.staticMapImageView)
-                    .load(safeLocationUiData.locationUrl)
-                    .apply(RequestOptions.centerCropTransform())
-                    .into(holder.staticMapImageView)
+            holder.staticMapView.getMapAsync { mapbox ->
+                mapbox.setStyle(safeLocationUiData.locationUrl)
+                safeLocationUiData.locationData?.let {
+                    mapbox.zoomToLocation(it, animate = false)
+                }
+                mapbox.uiSettings.setAllGesturesEnabled(false)
+            }
 
             safeLocationUiData.locationPinProvider.create(safeLocationUiData.locationOwnerId) { pinDrawable ->
                 GlideApp.with(holder.staticMapPinImageView)
@@ -124,7 +128,7 @@ abstract class BottomSheetMessagePreviewItem : VectorEpoxyModel<BottomSheetMessa
         val timestamp by bind<TextView>(R.id.bottom_sheet_message_preview_timestamp)
         val imagePreview by bind<ImageView>(R.id.bottom_sheet_message_preview_image)
         val mapViewContainer by bind<FrameLayout>(R.id.mapViewContainer)
-        val staticMapImageView by bind<ImageView>(R.id.staticMapImageView)
+        val staticMapView by bind<MapView>(R.id.staticMapView)
         val staticMapPinImageView by bind<ImageView>(R.id.staticMapPinImageView)
     }
 }

--- a/vector/src/main/java/im/vector/app/features/attachments/AttachmentTypeSelectorViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/attachments/AttachmentTypeSelectorViewModel.kt
@@ -34,7 +34,6 @@ class AttachmentTypeSelectorViewModel @AssistedInject constructor(
         @Assisted initialState: AttachmentTypeSelectorViewState,
         private val vectorFeatures: VectorFeatures,
         private val vectorPreferences: VectorPreferences,
-        private val urlMapProvider: UrlMapProvider
 ) : VectorViewModel<AttachmentTypeSelectorViewState, AttachmentTypeSelectorAction, EmptyViewEvents>(initialState) {
     @AssistedFactory
     interface Factory : MavericksAssistedViewModelFactory<AttachmentTypeSelectorViewModel, AttachmentTypeSelectorViewState> {
@@ -50,7 +49,7 @@ class AttachmentTypeSelectorViewModel @AssistedInject constructor(
     init {
         setState {
             copy(
-                    isLocationVisible = vectorFeatures.isLocationSharingEnabled() && urlMapProvider.isMapConfigurationAvailable(),
+                    isLocationVisible = vectorFeatures.isLocationSharingEnabled(),
                     isVoiceBroadcastVisible = vectorFeatures.isVoiceBroadcastEnabled(),
                     isTextFormattingEnabled = vectorPreferences.isTextFormattingEnabled(),
             )

--- a/vector/src/main/java/im/vector/app/features/attachments/AttachmentTypeSelectorViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/attachments/AttachmentTypeSelectorViewModel.kt
@@ -27,12 +27,14 @@ import im.vector.app.core.platform.EmptyViewEvents
 import im.vector.app.core.platform.VectorViewModel
 import im.vector.app.core.platform.VectorViewModelAction
 import im.vector.app.features.VectorFeatures
+import im.vector.app.features.location.UrlMapProvider
 import im.vector.app.features.settings.VectorPreferences
 
 class AttachmentTypeSelectorViewModel @AssistedInject constructor(
         @Assisted initialState: AttachmentTypeSelectorViewState,
         private val vectorFeatures: VectorFeatures,
         private val vectorPreferences: VectorPreferences,
+        private val urlMapProvider: UrlMapProvider
 ) : VectorViewModel<AttachmentTypeSelectorViewState, AttachmentTypeSelectorAction, EmptyViewEvents>(initialState) {
     @AssistedFactory
     interface Factory : MavericksAssistedViewModelFactory<AttachmentTypeSelectorViewModel, AttachmentTypeSelectorViewState> {
@@ -48,7 +50,7 @@ class AttachmentTypeSelectorViewModel @AssistedInject constructor(
     init {
         setState {
             copy(
-                    isLocationVisible = vectorFeatures.isLocationSharingEnabled(),
+                    isLocationVisible = vectorFeatures.isLocationSharingEnabled() && urlMapProvider.isMapConfigurationAvailable(),
                     isVoiceBroadcastVisible = vectorFeatures.isVoiceBroadcastEnabled(),
                     isTextFormattingEnabled = vectorPreferences.isTextFormattingEnabled(),
             )

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivityViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivityViewModel.kt
@@ -36,6 +36,7 @@ import im.vector.app.features.analytics.extensions.toAnalyticsType
 import im.vector.app.features.analytics.plan.Signup
 import im.vector.app.features.analytics.store.AnalyticsStore
 import im.vector.app.features.home.room.list.home.release.ReleaseNotesPreferencesStore
+import im.vector.app.features.location.UrlMapProvider
 import im.vector.app.features.login.ReAuthHelper
 import im.vector.app.features.onboarding.AuthenticationDescription
 import im.vector.app.features.raw.wellknown.ElementWellKnown
@@ -95,6 +96,7 @@ class HomeActivityViewModel @AssistedInject constructor(
         private val registerUnifiedPushUseCase: RegisterUnifiedPushUseCase,
         private val unregisterUnifiedPushUseCase: UnregisterUnifiedPushUseCase,
         private val ensureFcmTokenIsRetrievedUseCase: EnsureFcmTokenIsRetrievedUseCase,
+        private val mapUrlProvider: UrlMapProvider,
 ) : VectorViewModel<HomeActivityViewState, HomeActivityViewActions, HomeActivityViewEvents>(initialState) {
 
     @AssistedFactory
@@ -383,6 +385,9 @@ class HomeActivityViewModel @AssistedInject constructor(
             }
 
             val elementWellKnown = rawService.getElementWellknown(session.sessionParams)
+
+            mapUrlProvider.initWithWellknown(elementWellKnown)
+
             val isSecureBackupRequired = elementWellKnown?.isSecureBackupRequired() ?: false
 
             // In case of account creation, it is already done before

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerFragment.kt
@@ -88,6 +88,7 @@ import im.vector.app.features.home.room.detail.timeline.action.MessageSharedActi
 import im.vector.app.features.home.room.detail.upgrade.MigrateRoomBottomSheet
 import im.vector.app.features.html.PillImageSpan
 import im.vector.app.features.location.LocationSharingMode
+import im.vector.app.features.location.UrlMapProvider
 import im.vector.app.features.poll.PollMode
 import im.vector.app.features.settings.VectorPreferences
 import im.vector.app.features.share.SharedData
@@ -121,6 +122,7 @@ class MessageComposerFragment : VectorBaseFragment<FragmentComposerBinding>(), A
     @Inject lateinit var buildMeta: BuildMeta
     @Inject lateinit var session: Session
     @Inject lateinit var errorTracker: ErrorTracker
+    @Inject lateinit var urlMapProvider: UrlMapProvider
 
     private val roomId: String get() = withState(timelineViewModel) { it.roomId }
 
@@ -356,7 +358,7 @@ class MessageComposerFragment : VectorBaseFragment<FragmentComposerBinding>(), A
                         attachmentTypeSelector = AttachmentTypeSelectorView(vectorBaseActivity, vectorBaseActivity.layoutInflater, this@MessageComposerFragment)
                         attachmentTypeSelector.setAttachmentVisibility(
                                 AttachmentType.LOCATION,
-                                vectorFeatures.isLocationSharingEnabled(),
+                                vectorFeatures.isLocationSharingEnabled() && urlMapProvider.isMapConfigurationAvailable(),
                         )
                         attachmentTypeSelector.setAttachmentVisibility(
                                 AttachmentType.POLL, !isThreadTimeLine()

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerFragment.kt
@@ -88,7 +88,6 @@ import im.vector.app.features.home.room.detail.timeline.action.MessageSharedActi
 import im.vector.app.features.home.room.detail.upgrade.MigrateRoomBottomSheet
 import im.vector.app.features.html.PillImageSpan
 import im.vector.app.features.location.LocationSharingMode
-import im.vector.app.features.location.UrlMapProvider
 import im.vector.app.features.poll.PollMode
 import im.vector.app.features.settings.VectorPreferences
 import im.vector.app.features.share.SharedData
@@ -122,7 +121,6 @@ class MessageComposerFragment : VectorBaseFragment<FragmentComposerBinding>(), A
     @Inject lateinit var buildMeta: BuildMeta
     @Inject lateinit var session: Session
     @Inject lateinit var errorTracker: ErrorTracker
-    @Inject lateinit var urlMapProvider: UrlMapProvider
 
     private val roomId: String get() = withState(timelineViewModel) { it.roomId }
 
@@ -358,7 +356,7 @@ class MessageComposerFragment : VectorBaseFragment<FragmentComposerBinding>(), A
                         attachmentTypeSelector = AttachmentTypeSelectorView(vectorBaseActivity, vectorBaseActivity.layoutInflater, this@MessageComposerFragment)
                         attachmentTypeSelector.setAttachmentVisibility(
                                 AttachmentType.LOCATION,
-                                vectorFeatures.isLocationSharingEnabled() && urlMapProvider.isMapConfigurationAvailable(),
+                                vectorFeatures.isLocationSharingEnabled(),
                         )
                         attachmentTypeSelector.setAttachmentVisibility(
                                 AttachmentType.POLL, !isThreadTimeLine()

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/action/LocationUiData.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/action/LocationUiData.kt
@@ -17,11 +17,13 @@
 package im.vector.app.features.home.room.detail.timeline.action
 
 import im.vector.app.features.home.room.detail.timeline.helper.LocationPinProvider
+import im.vector.app.features.location.LocationData
 
 /**
  * Data used to display Location data in the message bottom sheet.
  */
 data class LocationUiData(
+        val locationData: LocationData?,
         val locationUrl: String,
         val locationOwnerId: String?,
         val locationPinProvider: LocationPinProvider,

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/action/MessageActionsEpoxyController.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/action/MessageActionsEpoxyController.kt
@@ -39,7 +39,6 @@ import im.vector.app.features.home.room.detail.timeline.item.E2EDecoration
 import im.vector.app.features.home.room.detail.timeline.tools.createLinkMovementMethod
 import im.vector.app.features.home.room.detail.timeline.tools.linkify
 import im.vector.app.features.html.SpanUtils
-import im.vector.app.features.location.INITIAL_MAP_ZOOM_IN_TIMELINE
 import im.vector.app.features.location.UrlMapProvider
 import im.vector.app.features.location.toLocationData
 import im.vector.app.features.media.ImageContentRenderer
@@ -228,13 +227,12 @@ class MessageActionsEpoxyController @Inject constructor(
 
         val locationContent = state.timelineEvent()?.root?.getClearContent().toModel<MessageLocationContent>(catchError = true)
                 ?: return null
-        val locationUrl = locationContent.toLocationData()
-                ?.let { urlMapProvider.buildStaticMapUrl(it, INITIAL_MAP_ZOOM_IN_TIMELINE, 1200, 800) }
-                ?: return null
+
         val locationOwnerId = if (locationContent.isSelfLocation()) state.informationData.matrixItem.id else null
 
         return LocationUiData(
-                locationUrl = locationUrl,
+                locationData = locationContent.toLocationData(),
+                locationUrl = urlMapProvider.getMapStyleUrl(),
                 locationOwnerId = locationOwnerId,
                 locationPinProvider = locationPinProvider,
         )

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/LiveLocationShareMessageItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/LiveLocationShareMessageItemFactory.kt
@@ -30,7 +30,6 @@ import im.vector.app.features.home.room.detail.timeline.item.MessageLiveLocation
 import im.vector.app.features.home.room.detail.timeline.item.MessageLiveLocationItem_
 import im.vector.app.features.home.room.detail.timeline.item.MessageLiveLocationStartItem
 import im.vector.app.features.home.room.detail.timeline.item.MessageLiveLocationStartItem_
-import im.vector.app.features.location.INITIAL_MAP_ZOOM_IN_TIMELINE
 import im.vector.app.features.location.UrlMapProvider
 import im.vector.app.features.location.toLocationData
 import org.matrix.android.sdk.api.session.Session
@@ -105,13 +104,12 @@ class LiveLocationShareMessageItemFactory @Inject constructor(
         val width = timelineMediaSizeProvider.getMaxSize().first
         val height = dimensionConverter.dpToPx(MessageItemFactory.MESSAGE_LOCATION_ITEM_HEIGHT_IN_DP)
 
-        val locationUrl = runningState.lastGeoUri.toLocationData()?.let {
-            urlMapProvider.buildStaticMapUrl(it, INITIAL_MAP_ZOOM_IN_TIMELINE, width, height)
-        }
+        val lastLocationData = runningState.lastGeoUri.toLocationData()
 
         return MessageLiveLocationItem_()
                 .attributes(attributes)
-                .locationUrl(locationUrl)
+                .locationData(lastLocationData)
+                .mapStyleUrl(urlMapProvider.getMapStyleUrl())
                 .mapWidth(width)
                 .mapHeight(height)
                 .locationUserId(attributes.informationData.senderId)

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/MessageItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/MessageItemFactory.kt
@@ -73,7 +73,6 @@ import im.vector.app.features.html.EventHtmlRenderer
 import im.vector.app.features.html.PillsPostProcessor
 import im.vector.app.features.html.SpanUtils
 import im.vector.app.features.html.VectorHtmlCompressor
-import im.vector.app.features.location.INITIAL_MAP_ZOOM_IN_TIMELINE
 import im.vector.app.features.location.UrlMapProvider
 import im.vector.app.features.location.toLocationData
 import im.vector.app.features.media.ImageContentRenderer
@@ -222,15 +221,12 @@ class MessageItemFactory @Inject constructor(
         val width = timelineMediaSizeProvider.getMaxSize().first
         val height = dimensionConverter.dpToPx(MESSAGE_LOCATION_ITEM_HEIGHT_IN_DP)
 
-        val locationUrl = locationContent.toLocationData()?.let {
-            urlMapProvider.buildStaticMapUrl(it, INITIAL_MAP_ZOOM_IN_TIMELINE, width, height)
-        }
-
         val locationUserId = if (locationContent.isSelfLocation()) informationData.senderId else null
 
         return MessageLocationItem_()
                 .attributes(attributes)
-                .locationUrl(locationUrl)
+                .locationData(locationContent.toLocationData())
+                .mapStyleUrl(urlMapProvider.getMapStyleUrl())
                 .mapWidth(width)
                 .mapHeight(height)
                 .locationUserId(locationUserId)

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/AbsMessageLocationItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/AbsMessageLocationItem.kt
@@ -63,19 +63,6 @@ abstract class AbsMessageLocationItem<H : AbsMessageLocationItem.Holder>(
         bindMap(holder)
     }
 
-    var failedLoadingMapListener : MapView.OnDidFailLoadingMapListener? = null
-    var finishedLoadingMapListener : MapView.OnDidFinishLoadingMapListener? = null
-
-    override fun unbind(holder: H) {
-        super.unbind(holder)
-        failedLoadingMapListener?.let {
-            holder.staticMapView.removeOnDidFailLoadingMapListener(it)
-        }
-        finishedLoadingMapListener?.let {
-            holder.staticMapView.removeOnDidFinishLoadingMapListener(it)
-        }
-    }
-
     override fun onViewAttachedToWindow(holder: H) {
         super.onViewAttachedToWindow(holder)
         holder.staticMapView.onStart()
@@ -95,30 +82,24 @@ abstract class AbsMessageLocationItem<H : AbsMessageLocationItem.Holder>(
             RoundedCorners(dimensionConverter.dpToPx(8))
         }
 
-        failedLoadingMapListener = MapView.OnDidFailLoadingMapListener {
-            holder.staticMapLoadingErrorView.isVisible = true
-            val mapErrorViewState = MapLoadingErrorViewState(imageCornerTransformation)
-            holder.staticMapLoadingErrorView.render(mapErrorViewState)
-        }
-
-        finishedLoadingMapListener = MapView.OnDidFinishLoadingMapListener {
-            locationPinProvider?.create(locationUserId) { pinDrawable ->
-                holder.staticMapPinImageView.setImageDrawable(pinDrawable)
-            }
-            holder.staticMapLoadingErrorView.isVisible = false
-        }
-
         holder.staticMapView.apply {
             updateLayoutParams {
                 width = mapWidth
                 height = mapHeight
             }
-            failedLoadingMapListener?.let {
-                addOnDidFailLoadingMapListener(it)
+            addOnDidFailLoadingMapListener {
+                holder.staticMapLoadingErrorView.isVisible = true
+                val mapErrorViewState = MapLoadingErrorViewState(imageCornerTransformation)
+                holder.staticMapLoadingErrorView.render(mapErrorViewState)
             }
-            finishedLoadingMapListener?.let {
-                addOnDidFinishLoadingMapListener(it)
+
+            addOnDidFinishLoadingMapListener {
+                locationPinProvider?.create(locationUserId) { pinDrawable ->
+                    holder.staticMapPinImageView.setImageDrawable(pinDrawable)
+                }
+                holder.staticMapLoadingErrorView.isVisible = false
             }
+
             clipToOutline = true
             getMapAsync { mapbox ->
                 mapbox.setStyle(mapStyleUrl)

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/AbsMessageLocationItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/AbsMessageLocationItem.kt
@@ -16,35 +16,34 @@
 
 package im.vector.app.features.home.room.detail.timeline.item
 
-import android.graphics.drawable.Drawable
 import android.widget.ImageView
-import android.widget.TextView
 import androidx.annotation.IdRes
 import androidx.annotation.LayoutRes
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import com.airbnb.epoxy.EpoxyAttribute
-import com.bumptech.glide.load.DataSource
-import com.bumptech.glide.load.engine.GlideException
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners
-import com.bumptech.glide.request.RequestListener
-import com.bumptech.glide.request.RequestOptions
-import com.bumptech.glide.request.target.Target
+import com.mapbox.mapboxsdk.maps.MapView
 import im.vector.app.R
-import im.vector.app.core.glide.GlideApp
+import im.vector.app.core.epoxy.ClickListener
 import im.vector.app.core.utils.DimensionConverter
 import im.vector.app.features.home.room.detail.timeline.helper.LocationPinProvider
 import im.vector.app.features.home.room.detail.timeline.style.TimelineMessageLayout
 import im.vector.app.features.home.room.detail.timeline.style.granularRoundedCorners
+import im.vector.app.features.location.LocationData
 import im.vector.app.features.location.MapLoadingErrorView
 import im.vector.app.features.location.MapLoadingErrorViewState
+import im.vector.app.features.location.zoomToLocation
 
 abstract class AbsMessageLocationItem<H : AbsMessageLocationItem.Holder>(
         @LayoutRes layoutId: Int = R.layout.item_timeline_event_base
 ) : AbsMessageItem<H>(layoutId) {
 
     @EpoxyAttribute
-    var locationUrl: String? = null
+    var locationData: LocationData? = null
+
+    @EpoxyAttribute
+    var mapStyleUrl: String? = null
 
     @EpoxyAttribute
     var locationUserId: String? = null
@@ -65,7 +64,6 @@ abstract class AbsMessageLocationItem<H : AbsMessageLocationItem.Holder>(
     }
 
     private fun bindMap(holder: Holder) {
-        val location = locationUrl ?: return
         val messageLayout = attributes.informationData.messageLayout
         val imageCornerTransformation = if (messageLayout is TimelineMessageLayout.Bubble) {
             messageLayout.cornersRadius.granularRoundedCorners()
@@ -73,53 +71,45 @@ abstract class AbsMessageLocationItem<H : AbsMessageLocationItem.Holder>(
             val dimensionConverter = DimensionConverter(holder.view.resources)
             RoundedCorners(dimensionConverter.dpToPx(8))
         }
-        holder.staticMapImageView.updateLayoutParams {
+        holder.staticMapView.updateLayoutParams {
             width = mapWidth
             height = mapHeight
         }
-        GlideApp.with(holder.staticMapImageView)
-                .load(location)
-                .apply(RequestOptions.centerCropTransform())
-                .placeholder(holder.staticMapImageView.drawable)
-                .listener(object : RequestListener<Drawable> {
-                    override fun onLoadFailed(
-                            e: GlideException?,
-                            model: Any?,
-                            target: Target<Drawable>?,
-                            isFirstResource: Boolean
-                    ): Boolean {
-                        holder.staticMapPinImageView.setImageDrawable(null)
-                        holder.staticMapLoadingErrorView.isVisible = true
-                        val mapErrorViewState = MapLoadingErrorViewState(imageCornerTransformation)
-                        holder.staticMapLoadingErrorView.render(mapErrorViewState)
-                        holder.staticMapCopyrightTextView.isVisible = false
-                        return false
-                    }
 
-                    override fun onResourceReady(
-                            resource: Drawable?,
-                            model: Any?,
-                            target: Target<Drawable>?,
-                            dataSource: DataSource?,
-                            isFirstResource: Boolean
-                    ): Boolean {
-                        locationPinProvider?.create(locationUserId) { pinDrawable ->
-                            // we are not using Glide since it does not display it correctly when there is no user photo
-                            holder.staticMapPinImageView.setImageDrawable(pinDrawable)
-                        }
-                        holder.staticMapLoadingErrorView.isVisible = false
-                        holder.staticMapCopyrightTextView.isVisible = true
-                        return false
-                    }
-                })
-                .transform(imageCornerTransformation)
-                .into(holder.staticMapImageView)
+        holder.staticMapView.addOnDidFailLoadingMapListener {
+            holder.staticMapLoadingErrorView.isVisible = true
+            val mapErrorViewState = MapLoadingErrorViewState(imageCornerTransformation)
+            holder.staticMapLoadingErrorView.render(mapErrorViewState)
+        }
+
+        holder.staticMapView.addOnDidFinishLoadingMapListener {
+            locationPinProvider?.create(locationUserId) { pinDrawable ->
+                holder.staticMapPinImageView.setImageDrawable(pinDrawable)
+            }
+            holder.staticMapLoadingErrorView.isVisible = false
+        }
+
+        holder.staticMapView.clipToOutline = true
+        holder.staticMapView.getMapAsync { mapbox ->
+            mapbox.setStyle(mapStyleUrl)
+            locationData?.let {
+                mapbox.zoomToLocation(it, animate = false)
+            }
+            mapbox.uiSettings.setAllGesturesEnabled(false)
+            mapbox.addOnMapClickListener {
+                attributes.itemClickListener?.invoke(holder.staticMapView)
+                true
+            }
+            mapbox.addOnMapLongClickListener {
+                attributes.itemLongClickListener?.onLongClick(holder.staticMapView)
+                true
+            }
+        }
     }
 
     abstract class Holder(@IdRes stubId: Int) : AbsMessageItem.Holder(stubId) {
-        val staticMapImageView by bind<ImageView>(R.id.staticMapImageView)
+        val staticMapView by bind<MapView>(R.id.staticMapView)
         val staticMapPinImageView by bind<ImageView>(R.id.staticMapPinImageView)
         val staticMapLoadingErrorView by bind<MapLoadingErrorView>(R.id.staticMapLoadingError)
-        val staticMapCopyrightTextView by bind<TextView>(R.id.staticMapCopyrightTextView)
     }
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/AbsMessageLocationItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/AbsMessageLocationItem.kt
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 New Vector Ltd
+ * Copyright (c) 2022 BWI GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/vector/src/main/java/im/vector/app/features/location/LocationSharingConfig.kt
+++ b/vector/src/main/java/im/vector/app/features/location/LocationSharingConfig.kt
@@ -18,4 +18,5 @@ package im.vector.app.features.location
 
 data class LocationSharingConfig(
         val mapTilerKey: String,
+        val isMapTilerFallbackEnabled: Boolean
 )

--- a/vector/src/main/java/im/vector/app/features/location/LocationSharingFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/location/LocationSharingFragment.kt
@@ -99,7 +99,7 @@ class LocationSharingFragment :
 
         lifecycleScope.launchWhenCreated {
             views.mapView.initialize(
-                    url = urlMapProvider.getMapUrl(),
+                    url = urlMapProvider.getMapStyleUrl(),
                     locationTargetChangeListener = this@LocationSharingFragment
             )
         }

--- a/vector/src/main/java/im/vector/app/features/location/MapBoxMapExt.kt
+++ b/vector/src/main/java/im/vector/app/features/location/MapBoxMapExt.kt
@@ -22,16 +22,16 @@ import com.mapbox.mapboxsdk.geometry.LatLng
 import com.mapbox.mapboxsdk.geometry.LatLngBounds
 import com.mapbox.mapboxsdk.maps.MapboxMap
 
-fun MapboxMap?.zoomToLocation(locationData: LocationData, preserveCurrentZoomLevel: Boolean = false, animate: Boolean = true) {
-    val zoomLevel = if (preserveCurrentZoomLevel && this?.cameraPosition != null) {
-        cameraPosition.zoom
-    } else {
-        INITIAL_MAP_ZOOM_IN_PREVIEW
-    }
-    val cameraPosition =  CameraPosition.Builder()
+fun MapboxMap?.zoomToLocation(
+        locationData: LocationData,
+        animate: Boolean = true,
+        zoomLevel: Double = INITIAL_MAP_ZOOM_IN_PREVIEW) {
+
+    val cameraPosition = CameraPosition.Builder()
             .target(LatLng(locationData.latitude, locationData.longitude))
             .zoom(zoomLevel)
             .build()
+
     if(animate) {
         this?.easeCamera {
             cameraPosition

--- a/vector/src/main/java/im/vector/app/features/location/MapBoxMapExt.kt
+++ b/vector/src/main/java/im/vector/app/features/location/MapBoxMapExt.kt
@@ -22,17 +22,24 @@ import com.mapbox.mapboxsdk.geometry.LatLng
 import com.mapbox.mapboxsdk.geometry.LatLngBounds
 import com.mapbox.mapboxsdk.maps.MapboxMap
 
-fun MapboxMap?.zoomToLocation(locationData: LocationData, preserveCurrentZoomLevel: Boolean = false) {
+fun MapboxMap?.zoomToLocation(locationData: LocationData, preserveCurrentZoomLevel: Boolean = false, animate: Boolean = true) {
     val zoomLevel = if (preserveCurrentZoomLevel && this?.cameraPosition != null) {
         cameraPosition.zoom
     } else {
         INITIAL_MAP_ZOOM_IN_PREVIEW
     }
-    this?.easeCamera {
-        CameraPosition.Builder()
-                .target(LatLng(locationData.latitude, locationData.longitude))
-                .zoom(zoomLevel)
-                .build()
+    val cameraPosition =  CameraPosition.Builder()
+            .target(LatLng(locationData.latitude, locationData.longitude))
+            .zoom(zoomLevel)
+            .build()
+    if(animate) {
+        this?.easeCamera {
+            cameraPosition
+        }
+    } else {
+        this?.moveCamera {
+            cameraPosition
+        }
     }
 }
 

--- a/vector/src/main/java/im/vector/app/features/location/UrlMapProvider.kt
+++ b/vector/src/main/java/im/vector/app/features/location/UrlMapProvider.kt
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 New Vector Ltd
+ * Copyright (c) 2022 BWI GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/vector/src/main/java/im/vector/app/features/location/UrlMapProvider.kt
+++ b/vector/src/main/java/im/vector/app/features/location/UrlMapProvider.kt
@@ -16,22 +16,25 @@
 
 package im.vector.app.features.location
 
-import im.vector.app.features.raw.wellknown.ElementWellKnown
+import androidx.annotation.VisibleForTesting
+import im.vector.app.features.raw.wellknown.WellknownService
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class UrlMapProvider @Inject constructor() {
+class UrlMapProvider @Inject constructor(
+        private val wellknownService: WellknownService,
+        private val locationSharingConfig: LocationSharingConfig,
+) {
+    private val keyParam = "?key=${locationSharingConfig.mapTilerKey}"
 
-    private var styleUrl : String = ""
-
-    fun initWithWellknown(data: ElementWellKnown?) {
-        styleUrl = data?.getBestMapTileServerConfig()?.mapStyleUrl ?: ""
+    @VisibleForTesting
+    val fallbackMapUrl = buildString {
+        append(MAP_BASE_URL)
+        append(keyParam)
     }
 
-    fun isMapConfigurationAvailable() = styleUrl.isNotEmpty()
-
-    fun getMapStyleUrl(): String {
-        return styleUrl
+    fun getMapStyleUrl() : String {
+        return wellknownService.getMapStyleUrl() ?: if (locationSharingConfig.isMapTilerFallbackEnabled) fallbackMapUrl else ""
     }
 }

--- a/vector/src/main/java/im/vector/app/features/location/UrlMapProvider.kt
+++ b/vector/src/main/java/im/vector/app/features/location/UrlMapProvider.kt
@@ -16,52 +16,22 @@
 
 package im.vector.app.features.location
 
-import im.vector.app.features.raw.wellknown.getElementWellknown
-import org.matrix.android.sdk.api.extensions.tryOrNull
-import org.matrix.android.sdk.api.raw.RawService
-import org.matrix.android.sdk.api.session.Session
+import im.vector.app.features.raw.wellknown.ElementWellKnown
 import javax.inject.Inject
+import javax.inject.Singleton
 
-class UrlMapProvider @Inject constructor(
-        private val session: Session,
-        private val rawService: RawService,
-        locationSharingConfig: LocationSharingConfig,
-) {
-    private val keyParam = "?key=${locationSharingConfig.mapTilerKey}"
+@Singleton
+class UrlMapProvider @Inject constructor() {
 
-    private val fallbackMapUrl = buildString {
-        append(MAP_BASE_URL)
-        append(keyParam)
+    private var styleUrl : String = ""
+
+    fun initWithWellknown(data: ElementWellKnown?) {
+        styleUrl = data?.getBestMapTileServerConfig()?.mapStyleUrl ?: ""
     }
 
-    suspend fun getMapUrl(): String {
-        val upstreamMapUrl = tryOrNull { rawService.getElementWellknown(session.sessionParams) }
-                ?.getBestMapTileServerConfig()
-                ?.mapStyleUrl
-        return upstreamMapUrl ?: fallbackMapUrl
-    }
+    fun isMapConfigurationAvailable() = styleUrl.isNotEmpty()
 
-    fun buildStaticMapUrl(
-            locationData: LocationData,
-            zoom: Double,
-            width: Int,
-            height: Int
-    ): String {
-        return buildString {
-            append(STATIC_MAP_BASE_URL)
-            append(locationData.longitude)
-            append(",")
-            append(locationData.latitude)
-            append(",")
-            append(zoom)
-            append("/")
-            append(width)
-            append("x")
-            append(height)
-            append(".png")
-            append(keyParam)
-            // Since the default copyright font is too small we put a custom one on map
-            append("&attribution=false")
-        }
+    fun getMapStyleUrl(): String {
+        return styleUrl
     }
 }

--- a/vector/src/main/java/im/vector/app/features/location/live/map/LiveLocationMapViewFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/location/live/map/LiveLocationMapViewFragment.kt
@@ -157,7 +157,7 @@ class LiveLocationMapViewFragment :
         symbol?.let {
             mapboxMap
                     ?.get()
-                    ?.zoomToLocation(LocationData(it.latLng.latitude, it.latLng.longitude, null), preserveCurrentZoomLevel = false)
+                    ?.zoomToLocation(LocationData(it.latLng.latitude, it.latLng.longitude, null))
 
             LiveLocationMapMarkerOptionsDialog(requireContext())
                     .apply {
@@ -332,7 +332,7 @@ class LiveLocationMapViewFragment :
                 .find { it.matrixItem.id == userId }
                 ?.locationData
                 ?.let { locationData ->
-                    mapboxMap?.get()?.zoomToLocation(locationData, preserveCurrentZoomLevel = false)
+                    mapboxMap?.get()?.zoomToLocation(locationData, true)
                 }
     }
 

--- a/vector/src/main/java/im/vector/app/features/location/live/map/LiveLocationMapViewFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/location/live/map/LiveLocationMapViewFragment.kt
@@ -129,7 +129,7 @@ class LiveLocationMapViewFragment :
                 listenMapLoadingError(it)
             }
             lifecycleScope.launch {
-                mapboxMap.setStyle(urlMapProvider.getMapUrl()) { style ->
+                mapboxMap.setStyle(urlMapProvider.getMapStyleUrl()) { style ->
                     mapStyle = style
                     this@LiveLocationMapViewFragment.mapboxMap = WeakReference(mapboxMap)
                     symbolManager = SymbolManager(mapFragment.view as MapView, mapboxMap, style).apply {

--- a/vector/src/main/java/im/vector/app/features/location/preview/LocationPreviewFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/location/preview/LocationPreviewFragment.kt
@@ -75,7 +75,7 @@ class LocationPreviewFragment :
         views.mapView.onCreate(savedInstanceState)
 
         lifecycleScope.launchWhenCreated {
-            views.mapView.initialize(urlMapProvider.getMapUrl())
+            views.mapView.initialize(urlMapProvider.getMapStyleUrl())
             loadPinDrawable()
         }
     }

--- a/vector/src/main/java/im/vector/app/features/raw/wellknown/WellknownService.kt
+++ b/vector/src/main/java/im/vector/app/features/raw/wellknown/WellknownService.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.raw.wellknown
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.matrix.android.sdk.api.extensions.tryOrNull
+import org.matrix.android.sdk.api.raw.RawService
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class WellknownService @Inject constructor(
+        private val rawService: RawService
+) {
+    private var elementWellKnown : ElementWellKnown? = null
+
+    suspend fun getElementWellknown(domain: String): ElementWellKnown? {
+        elementWellKnown = withContext(Dispatchers.IO) {
+            tryOrNull { rawService.getWellknown(domain) }
+                    ?.let { ElementWellKnownMapper.from(it) }
+        }
+        return elementWellKnown
+    }
+
+    fun getMapStyleUrl() : String? {
+        return elementWellKnown?.mapTileServerConfig?.mapStyleUrl
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/raw/wellknown/WellknownService.kt
+++ b/vector/src/main/java/im/vector/app/features/raw/wellknown/WellknownService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 New Vector Ltd
+ * Copyright (c) 2022 BWI GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/vector/src/main/res/layout/item_bottom_sheet_message_preview.xml
+++ b/vector/src/main/res/layout/item_bottom_sheet_message_preview.xml
@@ -120,9 +120,10 @@
         tools:alpha="0.3"
         tools:visibility="visible">
 
-        <ImageView
-            android:id="@+id/staticMapImageView"
+        <com.mapbox.mapboxsdk.maps.MapView
+            android:id="@+id/staticMapView"
             android:layout_width="match_parent"
+            android:background="@drawable/rounded_rect_shape_8"
             android:layout_height="200dp"
             android:contentDescription="@string/a11y_static_map_image" />
 

--- a/vector/src/main/res/layout/item_timeline_event_location_stub.xml
+++ b/vector/src/main/res/layout/item_timeline_event_location_stub.xml
@@ -6,12 +6,12 @@
     android:layout_height="wrap_content">
 
     <!-- Size will be overrode -->
-    <ImageView
-        android:id="@+id/staticMapImageView"
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/staticMapView"
         android:layout_width="300dp"
         android:layout_height="200dp"
+        android:background="@drawable/rounded_rect_shape_8"
         android:contentDescription="@string/a11y_static_map_image"
-        android:scaleType="centerCrop"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         tools:src="@tools:sample/backgrounds/scenic" />
@@ -24,9 +24,9 @@
         android:importantForAccessibility="no"
         android:src="@drawable/bg_map_user_pin"
         app:layout_constraintBottom_toTopOf="@id/staticMapVerticalCenter"
-        app:layout_constraintEnd_toEndOf="@id/staticMapImageView"
-        app:layout_constraintStart_toStartOf="@id/staticMapImageView"
-        app:layout_constraintTop_toTopOf="@id/staticMapImageView"
+        app:layout_constraintEnd_toEndOf="@id/staticMapView"
+        app:layout_constraintStart_toStartOf="@id/staticMapView"
+        app:layout_constraintTop_toTopOf="@id/staticMapView"
         app:layout_constraintVertical_bias="1.0" />
 
     <im.vector.app.features.location.MapLoadingErrorView
@@ -35,9 +35,9 @@
         android:layout_height="0dp"
         android:visibility="gone"
         app:layout_constraintBottom_toTopOf="@id/liveLocationRunningBanner"
-        app:layout_constraintEnd_toEndOf="@id/staticMapImageView"
-        app:layout_constraintStart_toStartOf="@id/staticMapImageView"
-        app:layout_constraintTop_toTopOf="@id/staticMapImageView"
+        app:layout_constraintEnd_toEndOf="@id/staticMapView"
+        app:layout_constraintStart_toStartOf="@id/staticMapView"
+        app:layout_constraintTop_toTopOf="@id/staticMapView"
         app:mapErrorDescription="@string/location_timeline_failed_to_load_map" />
 
     <im.vector.app.features.location.live.LiveLocationRunningBannerView
@@ -45,9 +45,9 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="@id/staticMapImageView"
-        app:layout_constraintEnd_toEndOf="@id/staticMapImageView"
-        app:layout_constraintStart_toStartOf="@id/staticMapImageView"
+        app:layout_constraintBottom_toBottomOf="@id/staticMapView"
+        app:layout_constraintEnd_toEndOf="@id/staticMapView"
+        app:layout_constraintStart_toStartOf="@id/staticMapView"
         tools:visibility="visible" />
 
     <androidx.constraintlayout.widget.Guideline
@@ -56,15 +56,5 @@
         android:layout_height="wrap_content"
         android:orientation="horizontal"
         app:layout_constraintGuide_percent="0.5" />
-
-    <TextView
-        android:id="@+id/staticMapCopyrightTextView"
-        style="@style/Widget.Vector.TextView.Nano.Copyright"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_margin="4dp"
-        android:text="@string/location_map_view_copyright"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/vector/src/test/java/im/vector/app/features/attachments/AttachmentTypeSelectorViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/attachments/AttachmentTypeSelectorViewModelTest.kt
@@ -17,13 +17,9 @@
 package im.vector.app.features.attachments
 
 import com.airbnb.mvrx.test.MavericksTestRule
-import im.vector.app.features.location.UrlMapProvider
-import im.vector.app.test.fakes.FakeUrlMapProvider
 import im.vector.app.test.fakes.FakeVectorFeatures
 import im.vector.app.test.fakes.FakeVectorPreferences
 import im.vector.app.test.test
-import io.mockk.every
-import io.mockk.mockk
 import io.mockk.verifyOrder
 import org.junit.Before
 import org.junit.Rule
@@ -37,7 +33,6 @@ internal class AttachmentTypeSelectorViewModelTest {
     private val fakeVectorFeatures = FakeVectorFeatures()
     private val fakeVectorPreferences = FakeVectorPreferences()
     private val initialState = AttachmentTypeSelectorViewState()
-    private val fakeUrlMapProvider = FakeUrlMapProvider()
 
     @Before
     fun setUp() {
@@ -62,29 +57,12 @@ internal class AttachmentTypeSelectorViewModelTest {
     @Test
     fun `given location sharing is enabled, then location sharing option is visible`() {
         fakeVectorFeatures.givenLocationSharing(isEnabled = true)
-        fakeUrlMapProvider.givenAvailableConfiguration()
         createViewModel()
                 .test()
                 .assertStates(
                         listOf(
                                 initialState.copy(
                                         isLocationVisible = true
-                                ),
-                        )
-                )
-                .finish()
-    }
-
-    @Test
-    fun `given location sharing is enabled, but no mapserver configuration available, then location sharing option is not visible`() {
-        fakeVectorFeatures.givenLocationSharing(isEnabled = true)
-        fakeUrlMapProvider.givenNotAvailableConfiguration()
-        createViewModel()
-                .test()
-                .assertStates(
-                        listOf(
-                                initialState.copy(
-                                        isLocationVisible = false
                                 ),
                         )
                 )
@@ -157,8 +135,7 @@ internal class AttachmentTypeSelectorViewModelTest {
         return AttachmentTypeSelectorViewModel(
                 initialState,
                 vectorFeatures = fakeVectorFeatures,
-                vectorPreferences = fakeVectorPreferences.instance,
-                urlMapProvider = fakeUrlMapProvider.instance
+                vectorPreferences = fakeVectorPreferences.instance
         )
     }
 }

--- a/vector/src/test/java/im/vector/app/features/attachments/AttachmentTypeSelectorViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/attachments/AttachmentTypeSelectorViewModelTest.kt
@@ -17,9 +17,13 @@
 package im.vector.app.features.attachments
 
 import com.airbnb.mvrx.test.MavericksTestRule
+import im.vector.app.features.location.UrlMapProvider
+import im.vector.app.test.fakes.FakeUrlMapProvider
 import im.vector.app.test.fakes.FakeVectorFeatures
 import im.vector.app.test.fakes.FakeVectorPreferences
 import im.vector.app.test.test
+import io.mockk.every
+import io.mockk.mockk
 import io.mockk.verifyOrder
 import org.junit.Before
 import org.junit.Rule
@@ -33,6 +37,7 @@ internal class AttachmentTypeSelectorViewModelTest {
     private val fakeVectorFeatures = FakeVectorFeatures()
     private val fakeVectorPreferences = FakeVectorPreferences()
     private val initialState = AttachmentTypeSelectorViewState()
+    private val fakeUrlMapProvider = FakeUrlMapProvider()
 
     @Before
     fun setUp() {
@@ -57,13 +62,29 @@ internal class AttachmentTypeSelectorViewModelTest {
     @Test
     fun `given location sharing is enabled, then location sharing option is visible`() {
         fakeVectorFeatures.givenLocationSharing(isEnabled = true)
-
+        fakeUrlMapProvider.givenAvailableConfiguration()
         createViewModel()
                 .test()
                 .assertStates(
                         listOf(
                                 initialState.copy(
                                         isLocationVisible = true
+                                ),
+                        )
+                )
+                .finish()
+    }
+
+    @Test
+    fun `given location sharing is enabled, but no mapserver configuration available, then location sharing option is not visible`() {
+        fakeVectorFeatures.givenLocationSharing(isEnabled = true)
+        fakeUrlMapProvider.givenNotAvailableConfiguration()
+        createViewModel()
+                .test()
+                .assertStates(
+                        listOf(
+                                initialState.copy(
+                                        isLocationVisible = false
                                 ),
                         )
                 )
@@ -137,6 +158,7 @@ internal class AttachmentTypeSelectorViewModelTest {
                 initialState,
                 vectorFeatures = fakeVectorFeatures,
                 vectorPreferences = fakeVectorPreferences.instance,
+                urlMapProvider = fakeUrlMapProvider.instance
         )
     }
 }

--- a/vector/src/test/java/im/vector/app/features/location/UrlMapProviderTest.kt
+++ b/vector/src/test/java/im/vector/app/features/location/UrlMapProviderTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.location
+
+import im.vector.app.test.fakes.FakeWellknownService
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+
+class UrlMapProviderTest {
+
+    @Test
+    fun `given enabled fallback to maptiler API, when map configuration is not set, then the fallback url should be returned`() {
+        val wellknownService = FakeWellknownService()
+        wellknownService.givenMissingMapConfiguration()
+        val urlMapProvider = UrlMapProvider(wellknownService.instance, LocationSharingConfig("", true))
+        urlMapProvider.getMapStyleUrl() shouldBeEqualTo urlMapProvider.fallbackMapUrl
+    }
+
+    @Test
+    fun `given enabled fallback to maptiler API, when map configuration is set, then the configurated url should be returned`() {
+        val wellknownService = FakeWellknownService()
+        wellknownService.givenValidMapConfiguration()
+        val urlMapProvider = UrlMapProvider(wellknownService.instance, LocationSharingConfig("", true))
+        urlMapProvider.getMapStyleUrl() shouldBeEqualTo wellknownService.A_MAPSTYLE_URL
+    }
+
+    @Test
+    fun `given disabled fallback to maptiler API, when map configuration is set, then the configurated url should be returned`() {
+        val wellknownService = FakeWellknownService()
+        wellknownService.givenValidMapConfiguration()
+        val urlMapProvider = UrlMapProvider(wellknownService.instance, LocationSharingConfig("", false))
+        urlMapProvider.getMapStyleUrl() shouldBeEqualTo wellknownService.A_MAPSTYLE_URL
+    }
+
+    @Test
+    fun `given disabled fallback to maptiler API, when map configuration is not set, then empty string should be returned`() {
+        val wellknownService = FakeWellknownService()
+        wellknownService.givenMissingMapConfiguration()
+        val urlMapProvider = UrlMapProvider(wellknownService.instance, LocationSharingConfig("", false))
+        urlMapProvider.getMapStyleUrl() shouldBeEqualTo ""
+    }
+}

--- a/vector/src/test/java/im/vector/app/features/location/UrlMapProviderTest.kt
+++ b/vector/src/test/java/im/vector/app/features/location/UrlMapProviderTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 New Vector Ltd
+ * Copyright (c) 2022 BWI GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeUrlMapProvider.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeUrlMapProvider.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.test.fakes
+
+import im.vector.app.features.location.UrlMapProvider
+import io.mockk.every
+import io.mockk.mockk
+
+class FakeUrlMapProvider {
+    val instance = mockk<UrlMapProvider>()
+
+    fun givenAvailableConfiguration() {
+        every { instance.isMapConfigurationAvailable() } returns true
+    }
+
+    fun givenNotAvailableConfiguration() {
+        every { instance.isMapConfigurationAvailable() } returns false
+    }
+}

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeWellknownService.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeWellknownService.kt
@@ -16,18 +16,20 @@
 
 package im.vector.app.test.fakes
 
-import im.vector.app.features.location.UrlMapProvider
+import im.vector.app.features.raw.wellknown.WellknownService
 import io.mockk.every
 import io.mockk.mockk
 
-class FakeUrlMapProvider {
-    val instance = mockk<UrlMapProvider>()
+class FakeWellknownService {
+    val A_MAPSTYLE_URL = "https://example.com/style.json"
 
-    fun givenAvailableConfiguration() {
-        every { instance.isMapConfigurationAvailable() } returns true
+    val instance = mockk<WellknownService>()
+
+    fun givenMissingMapConfiguration() {
+        every { instance.getMapStyleUrl() } returns null
     }
 
-    fun givenNotAvailableConfiguration() {
-        every { instance.isMapConfigurationAvailable() } returns false
+    fun givenValidMapConfiguration() {
+        every { instance.getMapStyleUrl() } returns A_MAPSTYLE_URL
     }
 }

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeWellknownService.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeWellknownService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 New Vector Ltd
+ * Copyright (c) 2022 BWI GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Type of change

- [x] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

The map server configuration (style.json), provided by the wellknown file, should be used for all use-cases, showing locations on a map.

## Motivation and context

The map configuration (style.json), provided by the wellknown is not used for displaying the location in the timeline. Currently the [Maptiler static map API](https://docs.maptiler.com/cloud/api/static-maps/) is used for this, which is loading map data from the other source. This is problematic, due to copyright and/or network limitations, which may prohibit the use of map sources other than specified in the wellknown file. 

This PR also removes the static attribution string, hard-coded in the app. The attribution should be defined in the `style.json` file to match the used data source.

## Tested devices

- [x] Physical
- [x] Emulator
- OS version(s):
API 21, API 33

Signed-off-by: Artjom König [artjom.koenig.ext@bwi.de](mailto:artjom.koenig.ext@bwi.de)