### PR TITLE
Add more migration logs

### DIFF
--- a/matrix-sdk-android/src/rustCrypto/java/org/matrix/android/sdk/internal/crypto/store/db/migration/rust/ExtractUtils.kt
+++ b/matrix-sdk-android/src/rustCrypto/java/org/matrix/android/sdk/internal/crypto/store/db/migration/rust/ExtractUtils.kt
@@ -71,6 +71,10 @@ fun RealmToMigrate.getPickledAccount(pickleKey: ByteArray): MigrationData {
             val userKey = metadataEntity.xSignUserPrivateKey
             val selfSignedKey = metadataEntity.xSignSelfSignedPrivateKey
 
+            Timber.i("## Migration: has private MSK ${masterKey.isNullOrBlank().not()}")
+            Timber.i("## Migration: has private USK ${userKey.isNullOrBlank().not()}")
+            Timber.i("## Migration: has private SSK ${selfSignedKey.isNullOrBlank().not()}")
+
             val userId = metadataEntity.userId
                     ?: throw java.lang.IllegalArgumentException("Rust db migration: userId is null")
             val deviceId = metadataEntity.deviceId
@@ -78,6 +82,8 @@ fun RealmToMigrate.getPickledAccount(pickleKey: ByteArray): MigrationData {
 
             val backupVersion = metadataEntity.backupVersion
             val backupRecoveryKey = metadataEntity.keyBackupRecoveryKey
+
+            Timber.i("## Migration: has private backup key ${backupRecoveryKey != null} for version $backupVersion")
 
             val isOlmAccountShared = metadataEntity.deviceKeysSentToServer
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->

Add more logs regarding secrets migration

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
