### PR TITLE
Make 'sign in' flow more important in the initial screen

### DIFF
--- a/changelog.d/+update-login-splash-screen.bugfix
+++ b/changelog.d/+update-login-splash-screen.bugfix
@@ -1,0 +1,1 @@
+Switch the position and styles of the 'already have an account' and 'create account' buttons in the login splash screen. Also changes the 'already have an account one' to just say 'sign in'.

--- a/library/ui-strings/src/main/res/values/strings.xml
+++ b/library/ui-strings/src/main/res/values/strings.xml
@@ -2095,6 +2095,7 @@
     <string name="login_splash_text2">Keep conversations private with encryption</string>
     <string name="login_splash_text3">Extend &amp; customize your experience</string>
     <string name="login_splash_submit">Get started</string>
+    <string name="login_splash_sign_in">Sign In</string>
     <string name="login_splash_create_account">Create account</string>
     <string name="login_splash_already_have_account">I already have an account</string>
 

--- a/vector/src/main/res/layout/fragment_ftue_splash_carousel.xml
+++ b/vector/src/main/res/layout/fragment_ftue_splash_carousel.xml
@@ -57,30 +57,30 @@
         app:layout_constraintTop_toBottomOf="@id/carouselIndicator" />
 
     <Button
-        android:id="@+id/loginSplashSubmit"
+        android:id="@+id/loginSplashAlreadyHaveAccount"
         style="@style/Widget.Vector.Button.Login"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:text="@string/login_splash_sign_in"
         android:textAllCaps="true"
         android:transitionName="loginSubmitTransition"
-        app:layout_constraintBottom_toTopOf="@id/loginSplashAlreadyHaveAccount"
+        app:layout_constraintBottom_toTopOf="@id/loginSplashSubmit"
         app:layout_constraintEnd_toEndOf="@id/splashCarouselGutterEnd"
         app:layout_constraintStart_toStartOf="@id/splashCarouselGutterStart"
-        app:layout_constraintTop_toBottomOf="@id/loginSplashButtonsSpace"
-        tools:text="@string/login_splash_create_account" />
+        app:layout_constraintTop_toBottomOf="@id/loginSplashButtonsSpace" />
 
     <Button
-        android:id="@+id/loginSplashAlreadyHaveAccount"
+        android:id="@+id/loginSplashSubmit"
         style="@style/Widget.Vector.Button.Text.Login"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:text="@string/login_splash_already_have_account"
         android:textAllCaps="true"
         android:transitionName="loginSubmitTransition"
         app:layout_constraintBottom_toTopOf="@id/loginSplashBottomSpace"
         app:layout_constraintEnd_toEndOf="@id/splashCarouselGutterEnd"
         app:layout_constraintStart_toStartOf="@id/splashCarouselGutterStart"
-        app:layout_constraintTop_toBottomOf="@id/loginSplashSubmit" />
+        app:layout_constraintTop_toBottomOf="@id/loginSplashAlreadyHaveAccount"
+        tools:text="@string/login_splash_create_account" />
 
     <Space
         android:id="@+id/loginSplashBottomSpace"


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other : design change.

## Content

- "I already have an account" and "Create account" buttons in the initial screens have swaped places and styles.
- "I already have an account" is now "Sign in" to make it clearer to the user.

## Motivation and context

Requested by a customer.

## Screenshots / GIFs

The new design should look like:

![image](https://github.com/element-hq/element-android/assets/480955/a3542cd0-f5a5-42d4-958f-484c1bd26d10)

## Tests

<!-- Explain how you tested your development -->

- Open the app, check the buttons look like the design above.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/element-hq/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
