### PR TITLE
[Crypto] Improve Event.getClearContent() and fix assignement issue.

### DIFF
--- a/changelog.d/8744.bugfix
+++ b/changelog.d/8744.bugfix
@@ -1,0 +1,1 @@
+Improve `Event.getClearContent()` and fix assignment issue that may help to decrypt last Event in the room list.

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/events/model/Event.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/events/model/Event.kt
@@ -219,10 +219,16 @@ data class Event(
     }
 
     /**
-     * @return the event content
+     * @return the event content.
+     * If the content is encrypted, it will return the decrypted content, or null if the content is not
+     * decrypted.
      */
     fun getClearContent(): Content? {
-        return getDecryptedContent() ?: content
+        return if (isEncrypted()) {
+            getDecryptedContent()
+        } else {
+            content
+        }
     }
 
     /**

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/RustCryptoService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/RustCryptoService.kt
@@ -664,7 +664,7 @@ internal class RustCryptoService @Inject constructor(
             when (event.type) {
                 EventType.ROOM_KEY -> {
                     val content = event.getClearContent().toModel<RoomKeyContent>() ?: return@forEach
-                    content.sessionKey
+
                     val roomId = content.sessionId ?: return@forEach
                     val sessionId = content.sessionId
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/RustCryptoService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/RustCryptoService.kt
@@ -627,7 +627,7 @@ internal class RustCryptoService @Inject constructor(
     }
 
     private fun notifyRoomKeyReceived(
-            roomId: String,
+            roomId: String?,
             sessionId: String,
     ) {
         megolmSessionImportManager.dispatchNewSession(roomId, sessionId)
@@ -665,8 +665,8 @@ internal class RustCryptoService @Inject constructor(
                 EventType.ROOM_KEY -> {
                     val content = event.getClearContent().toModel<RoomKeyContent>() ?: return@forEach
 
-                    val roomId = content.sessionId ?: return@forEach
-                    val sessionId = content.sessionId
+                    val roomId = content.roomId
+                    val sessionId = content.sessionId ?: return@forEach
 
                     notifyRoomKeyReceived(roomId, sessionId)
                     matrixConfiguration.cryptoAnalyticsPlugin?.onRoomKeyImported(sessionId, EventType.ROOM_KEY)
@@ -674,8 +674,8 @@ internal class RustCryptoService @Inject constructor(
                 EventType.FORWARDED_ROOM_KEY -> {
                     val content = event.getClearContent().toModel<ForwardedRoomKeyContent>() ?: return@forEach
 
-                    val roomId = content.sessionId ?: return@forEach
-                    val sessionId = content.sessionId
+                    val roomId = content.roomId
+                    val sessionId = content.sessionId ?: return@forEach
 
                     notifyRoomKeyReceived(roomId, sessionId)
                     matrixConfiguration.cryptoAnalyticsPlugin?.onRoomKeyImported(sessionId, EventType.FORWARDED_ROOM_KEY)

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/session/event/ValidDecryptedEventTest.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/session/event/ValidDecryptedEventTest.kt
@@ -89,7 +89,7 @@ class ValidDecryptedEventTest {
                 ).toContent()
         )
 
-        val unValidatedContent = mixedEvent.getClearContent().toModel<MessageTextContent>()
+        val unValidatedContent = mixedEvent.content.toModel<MessageTextContent>()
         unValidatedContent?.body shouldBe "some message"
 
         mixedEvent.toValidDecryptedEvent()?.clearContent?.toModel<MessageTextContent>() shouldBe null


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
The first commit should prevent encrypted content to be parsed as decoded Event. Hopefully there will be no side effect. I have checked and this should be fine.
The last commit is fixing an issue, calling `RoomService.refreshJoinedRoomSummaryPreviews` has never worked as expected with the Crypto Rust SDK.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Should fix lots of error logs when undecrypted Events content are mapped to Content model.

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Run the app and send encrypted message after discarding the session.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/element-hq/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
