### PR TITLE
Location avatar

### DIFF
--- a/changelog.d/8749.bugfix
+++ b/changelog.d/8749.bugfix
@@ -1,0 +1,1 @@
+Fix issues about location Event avatar rendering.

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/SessionExtensions.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/SessionExtensions.kt
@@ -19,6 +19,7 @@ package org.matrix.android.sdk.api.session
 import org.matrix.android.sdk.api.session.room.Room
 import org.matrix.android.sdk.api.session.room.model.RoomSummary
 import org.matrix.android.sdk.api.session.user.model.User
+import timber.log.Timber
 
 /**
  * Get a room using the RoomService of a Session.
@@ -41,4 +42,5 @@ fun Session.getUser(userId: String): User? = userService().getUser(userId)
 /**
  * Similar to [getUser], but fallback to a User without details if the User is not known by the SDK, or if Session is null.
  */
-fun Session?.getUserOrDefault(userId: String): User = this?.userService()?.getUser(userId) ?: User(userId)
+fun Session?.getUserOrDefault(userId: String): User = this?.userService()?.getUser(userId)
+        ?: User(userId).also { Timber.w("User $userId not found in local cache, fallback to default") }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/livelocation/LiveLocationShareAggregatedSummary.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/livelocation/LiveLocationShareAggregatedSummary.kt
@@ -22,6 +22,7 @@ import org.matrix.android.sdk.api.session.room.model.message.MessageBeaconLocati
  * Aggregation info concerning a live location share.
  */
 data class LiveLocationShareAggregatedSummary(
+        val roomId: String?,
         val userId: String?,
         /**
          * Indicate whether the live is currently running.

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/mapper/LiveLocationShareAggregatedSummaryMapper.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/mapper/LiveLocationShareAggregatedSummaryMapper.kt
@@ -28,6 +28,7 @@ internal class LiveLocationShareAggregatedSummaryMapper @Inject constructor() :
 
     override fun map(entity: LiveLocationShareAggregatedSummaryEntity): LiveLocationShareAggregatedSummary {
         return LiveLocationShareAggregatedSummary(
+                roomId = entity.roomId,
                 userId = entity.userId,
                 isActive = entity.isActive,
                 endOfLiveTimestampMillis = entity.endOfLiveTimestampMillis,

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/database/mapper/LiveLocationShareAggregatedSummaryMapperTest.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/database/mapper/LiveLocationShareAggregatedSummaryMapperTest.kt
@@ -24,6 +24,7 @@ import org.matrix.android.sdk.api.session.room.model.message.LocationInfo
 import org.matrix.android.sdk.api.session.room.model.message.MessageBeaconLocationDataContent
 import org.matrix.android.sdk.internal.database.model.livelocation.LiveLocationShareAggregatedSummaryEntity
 
+private const val ANY_ROOM_ID = "a-room-id"
 private const val ANY_USER_ID = "a-user-id"
 private const val ANY_ACTIVE_STATE = true
 private const val ANY_TIMEOUT = 123L
@@ -40,6 +41,7 @@ class LiveLocationShareAggregatedSummaryMapperTest {
         val summary = mapper.map(entity)
 
         summary shouldBeEqualTo LiveLocationShareAggregatedSummary(
+                roomId = ANY_ROOM_ID,
                 userId = ANY_USER_ID,
                 isActive = ANY_ACTIVE_STATE,
                 endOfLiveTimestampMillis = ANY_TIMEOUT,
@@ -48,6 +50,7 @@ class LiveLocationShareAggregatedSummaryMapperTest {
     }
 
     private fun anEntity(content: MessageBeaconLocationDataContent) = LiveLocationShareAggregatedSummaryEntity(
+            roomId = ANY_ROOM_ID,
             userId = ANY_USER_ID,
             isActive = ANY_ACTIVE_STATE,
             endOfLiveTimestampMillis = ANY_TIMEOUT,

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/session/room/location/DefaultLocationSharingServiceTest.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/session/room/location/DefaultLocationSharingServiceTest.kt
@@ -229,6 +229,7 @@ internal class DefaultLocationSharingServiceTest {
     fun `livedata of live summaries is correctly computed`() {
         val entity = LiveLocationShareAggregatedSummaryEntity()
         val summary = LiveLocationShareAggregatedSummary(
+                roomId = A_ROOM_ID,
                 userId = "",
                 isActive = true,
                 endOfLiveTimestampMillis = 123,
@@ -255,6 +256,7 @@ internal class DefaultLocationSharingServiceTest {
     fun `given an event id when getting livedata on corresponding live summary then it is correctly computed`() {
         val entity = LiveLocationShareAggregatedSummaryEntity()
         val summary = LiveLocationShareAggregatedSummary(
+                roomId = A_ROOM_ID,
                 userId = "",
                 isActive = true,
                 endOfLiveTimestampMillis = 123,

--- a/vector/src/main/java/im/vector/app/core/epoxy/bottomsheet/BottomSheetMessagePreviewItem.kt
+++ b/vector/src/main/java/im/vector/app/core/epoxy/bottomsheet/BottomSheetMessagePreviewItem.kt
@@ -103,7 +103,8 @@ abstract class BottomSheetMessagePreviewItem : VectorEpoxyModel<BottomSheetMessa
                     .apply(RequestOptions.centerCropTransform())
                     .into(holder.staticMapImageView)
 
-            safeLocationUiData.locationPinProvider.create(safeLocationUiData.locationOwnerId) { pinDrawable ->
+            val pinMatrixItem = matrixItem.takeIf { safeLocationUiData.locationOwnerId != null }
+            safeLocationUiData.locationPinProvider.create(pinMatrixItem) { pinDrawable ->
                 // we are not using Glide since it does not display it correctly when there is no user photo
                 holder.staticMapPinImageView.setImageDrawable(pinDrawable)
             }

--- a/vector/src/main/java/im/vector/app/core/epoxy/bottomsheet/BottomSheetMessagePreviewItem.kt
+++ b/vector/src/main/java/im/vector/app/core/epoxy/bottomsheet/BottomSheetMessagePreviewItem.kt
@@ -104,9 +104,8 @@ abstract class BottomSheetMessagePreviewItem : VectorEpoxyModel<BottomSheetMessa
                     .into(holder.staticMapImageView)
 
             safeLocationUiData.locationPinProvider.create(safeLocationUiData.locationOwnerId) { pinDrawable ->
-                GlideApp.with(holder.staticMapPinImageView)
-                        .load(pinDrawable)
-                        .into(holder.staticMapPinImageView)
+                // we are not using Glide since it does not display it correctly when there is no user photo
+                holder.staticMapPinImageView.setImageDrawable(pinDrawable)
             }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/action/MessageActionsEpoxyController.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/action/MessageActionsEpoxyController.kt
@@ -238,7 +238,7 @@ class MessageActionsEpoxyController @Inject constructor(
         val locationUrl = locationContent.toLocationData()
                 ?.let { urlMapProvider.buildStaticMapUrl(it, INITIAL_MAP_ZOOM_IN_TIMELINE, 1200, 800) }
                 ?: return null
-        val locationOwnerId = if (locationContent.isSelfLocation()) state.informationData.matrixItem.id else null
+        val locationOwnerId = if (locationContent.isSelfLocation()) state.informationData.senderId else null
 
         return LocationUiData(
                 locationUrl = locationUrl,

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/LiveLocationShareMessageItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/LiveLocationShareMessageItemFactory.kt
@@ -114,7 +114,7 @@ class LiveLocationShareMessageItemFactory @Inject constructor(
                 .locationUrl(locationUrl)
                 .mapWidth(width)
                 .mapHeight(height)
-                .locationUserId(attributes.informationData.senderId)
+                .pinMatrixItem(attributes.informationData.matrixItem)
                 .locationPinProvider(locationPinProvider)
                 .highlighted(highlight)
                 .leftGuideline(avatarSizeProvider.leftGuideline)

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/MessageItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/MessageItemFactory.kt
@@ -233,14 +233,14 @@ class MessageItemFactory @Inject constructor(
             urlMapProvider.buildStaticMapUrl(it, INITIAL_MAP_ZOOM_IN_TIMELINE, width, height)
         }
 
-        val locationUserId = if (locationContent.isSelfLocation()) informationData.senderId else null
+        val pinMatrixItem = if (locationContent.isSelfLocation()) informationData.matrixItem else null
 
         return MessageLocationItem_()
                 .attributes(attributes)
                 .locationUrl(locationUrl)
                 .mapWidth(width)
                 .mapHeight(height)
-                .locationUserId(locationUserId)
+                .pinMatrixItem(pinMatrixItem)
                 .locationPinProvider(locationPinProvider)
                 .highlighted(highlight)
                 .leftGuideline(avatarSizeProvider.leftGuideline)

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/AbsMessageLocationItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/AbsMessageLocationItem.kt
@@ -38,6 +38,7 @@ import im.vector.app.features.home.room.detail.timeline.style.TimelineMessageLay
 import im.vector.app.features.home.room.detail.timeline.style.granularRoundedCorners
 import im.vector.app.features.location.MapLoadingErrorView
 import im.vector.app.features.location.MapLoadingErrorViewState
+import org.matrix.android.sdk.api.util.MatrixItem
 
 abstract class AbsMessageLocationItem<H : AbsMessageLocationItem.Holder>(
         @LayoutRes layoutId: Int = R.layout.item_timeline_event_base
@@ -47,7 +48,7 @@ abstract class AbsMessageLocationItem<H : AbsMessageLocationItem.Holder>(
     var locationUrl: String? = null
 
     @EpoxyAttribute
-    var locationUserId: String? = null
+    var pinMatrixItem: MatrixItem? = null
 
     @EpoxyAttribute
     var mapWidth: Int = 0
@@ -103,7 +104,7 @@ abstract class AbsMessageLocationItem<H : AbsMessageLocationItem.Holder>(
                             dataSource: DataSource?,
                             isFirstResource: Boolean
                     ): Boolean {
-                        locationPinProvider?.create(locationUserId) { pinDrawable ->
+                        locationPinProvider?.create(pinMatrixItem) { pinDrawable ->
                             // we are not using Glide since it does not display it correctly when there is no user photo
                             holder.staticMapPinImageView.setImageDrawable(pinDrawable)
                         }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageLiveLocationItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageLiveLocationItem.kt
@@ -49,7 +49,7 @@ abstract class MessageLiveLocationItem : AbsMessageLocationItem<MessageLiveLocat
 
     private fun bindLiveLocationBanner(holder: Holder) {
         // TODO in a future PR add check on device id to confirm that is the one that sent the beacon
-        val isEmitter = currentUserId != null && currentUserId == locationUserId
+        val isEmitter = currentUserId != null && currentUserId == pinMatrixItem?.id
         val messageLayout = attributes.informationData.messageLayout
         val viewState = buildViewState(holder, messageLayout, isEmitter)
         holder.liveLocationRunningBanner.isVisible = true

--- a/vector/src/main/java/im/vector/app/features/location/LocationSharingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/location/LocationSharingViewModel.kt
@@ -106,11 +106,13 @@ class LocationSharingViewModel @AssistedInject constructor(
 
     private fun updatePin(isUserPin: Boolean? = true) {
         if (isUserPin.orFalse()) {
-            locationPinProvider.create(userId = session.myUserId) {
+            val matrixItem = room.membershipService().getRoomMember(session.myUserId)?.toMatrixItem()
+                    ?: session.getUserOrDefault(session.myUserId).toMatrixItem()
+            locationPinProvider.create(matrixItem) {
                 updatePinDrawableInState(it)
             }
         } else {
-            locationPinProvider.create(userId = null) {
+            locationPinProvider.create(null) {
                 updatePinDrawableInState(it)
             }
         }

--- a/vector/src/main/java/im/vector/app/features/location/preview/LocationPreviewViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/location/preview/LocationPreviewViewModel.kt
@@ -30,6 +30,8 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import org.matrix.android.sdk.api.session.Session
+import org.matrix.android.sdk.api.util.MatrixItem
+import org.matrix.android.sdk.api.util.toMatrixItem
 
 class LocationPreviewViewModel @AssistedInject constructor(
         @Assisted private val initialState: LocationPreviewViewState,
@@ -46,12 +48,23 @@ class LocationPreviewViewModel @AssistedInject constructor(
     companion object : MavericksViewModelFactory<LocationPreviewViewModel, LocationPreviewViewState> by hiltMavericksViewModelFactory()
 
     init {
-        initPin(initialState.pinUserId)
+        val matrixItem = if (initialState.roomId != null && initialState.pinUserId != null) {
+            session
+                    .roomService()
+                    .getRoom(initialState.roomId)
+                    ?.membershipService()
+                    ?.getRoomMember(initialState.pinUserId)
+                    ?.toMatrixItem()
+                    ?: MatrixItem.UserItem(initialState.pinUserId)
+        } else {
+            null
+        }
+        initPin(matrixItem)
         initLocationTracking()
     }
 
-    private fun initPin(userId: String?) {
-        locationPinProvider.create(userId) { pinDrawable ->
+    private fun initPin(matrixItem: MatrixItem?) {
+        locationPinProvider.create(matrixItem) { pinDrawable ->
             setState { copy(pinDrawable = pinDrawable) }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/location/preview/LocationPreviewViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/location/preview/LocationPreviewViewState.kt
@@ -23,6 +23,7 @@ import im.vector.app.features.location.LocationSharingArgs
 
 data class LocationPreviewViewState(
         val pinLocationData: LocationData? = null,
+        val roomId: String? = null,
         val pinUserId: String? = null,
         val pinDrawable: Drawable? = null,
         val loadingMapHasFailed: Boolean = false,
@@ -32,6 +33,7 @@ data class LocationPreviewViewState(
 
     constructor(args: LocationSharingArgs) : this(
             pinLocationData = args.initialLocationData,
+            roomId = args.roomId,
             pinUserId = args.locationOwnerId,
     )
 }

--- a/vector/src/test/java/im/vector/app/features/location/LocationDataTest.kt
+++ b/vector/src/test/java/im/vector/app/features/location/LocationDataTest.kt
@@ -17,6 +17,7 @@
 package im.vector.app.features.location
 
 import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeFalse
 import org.amshove.kluent.shouldBeNull
 import org.amshove.kluent.shouldBeTrue
 import org.junit.Test
@@ -80,6 +81,9 @@ class LocationDataTest {
 
         val contentWithSelfAssetType = MessageLocationContent(body = "", geoUri = "", unstableLocationAsset = LocationAsset(type = LocationAssetType.SELF))
         contentWithSelfAssetType.isSelfLocation().shouldBeTrue()
+
+        val contentWithPinAssetType = MessageLocationContent(body = "", geoUri = "", unstableLocationAsset = LocationAsset(type = LocationAssetType.PIN))
+        contentWithPinAssetType.isSelfLocation().shouldBeFalse()
     }
 
     @Test

--- a/vector/src/test/java/im/vector/app/features/location/live/GetLiveLocationShareSummaryUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/location/live/GetLiveLocationShareSummaryUseCaseTest.kt
@@ -54,6 +54,7 @@ class GetLiveLocationShareSummaryUseCaseTest {
     @Test
     fun `given a room id and event id when calling use case then flow on summary is returned`() = runTest {
         val summary = LiveLocationShareAggregatedSummary(
+                roomId = A_ROOM_ID,
                 userId = "userId",
                 isActive = true,
                 endOfLiveTimestampMillis = 123,

--- a/vector/src/test/java/im/vector/app/features/location/live/map/GetListOfUserLiveLocationUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/location/live/map/GetListOfUserLiveLocationUseCaseTest.kt
@@ -59,18 +59,21 @@ class GetListOfUserLiveLocationUseCaseTest {
     @Test
     fun `given a room id then the correct flow of view states list is collected`() = runTest {
         val summary1 = LiveLocationShareAggregatedSummary(
+                roomId = A_ROOM_ID,
                 userId = "userId1",
                 isActive = true,
                 endOfLiveTimestampMillis = 123,
                 lastLocationDataContent = MessageBeaconLocationDataContent()
         )
         val summary2 = LiveLocationShareAggregatedSummary(
+                roomId = A_ROOM_ID,
                 userId = "userId2",
                 isActive = true,
                 endOfLiveTimestampMillis = 1234,
                 lastLocationDataContent = MessageBeaconLocationDataContent()
         )
         val summary3 = LiveLocationShareAggregatedSummary(
+                roomId = A_ROOM_ID,
                 userId = "userId3",
                 isActive = true,
                 endOfLiveTimestampMillis = 1234,

--- a/vector/src/test/java/im/vector/app/features/location/live/map/UserLiveLocationViewStateMapperTest.kt
+++ b/vector/src/test/java/im/vector/app/features/location/live/map/UserLiveLocationViewStateMapperTest.kt
@@ -72,6 +72,7 @@ class UserLiveLocationViewStateMapperTest {
     @Test
     fun `given a summary with invalid data then result is null`() = runTest {
         val summary1 = LiveLocationShareAggregatedSummary(
+                roomId = null,
                 userId = null,
                 isActive = true,
                 endOfLiveTimestampMillis = null,
@@ -98,17 +99,19 @@ class UserLiveLocationViewStateMapperTest {
                 unstableTimestampMillis = A_LOCATION_TIMESTAMP
         )
         val summary = LiveLocationShareAggregatedSummary(
+                roomId = null,
                 userId = A_USER_ID,
                 isActive = A_IS_ACTIVE,
                 endOfLiveTimestampMillis = A_END_OF_LIVE_TIMESTAMP,
                 lastLocationDataContent = locationDataContent,
         )
-        locationPinProvider.givenCreateForUserId(A_USER_ID, pinDrawable)
+        val matrixItem = MatrixItem.UserItem(id = A_USER_ID, displayName = A_USER_DISPLAY_NAME, avatarUrl = "")
+        locationPinProvider.givenCreateForMatrixItem(matrixItem, pinDrawable)
 
         val viewState = userLiveLocationViewStateMapper.map(summary)
 
         val expectedViewState = UserLiveLocationViewState(
-                matrixItem = MatrixItem.UserItem(id = A_USER_ID, displayName = A_USER_DISPLAY_NAME, avatarUrl = ""),
+                matrixItem = matrixItem,
                 pinDrawable = pinDrawable,
                 locationData = LocationData(
                         latitude = A_LATITUDE,

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeLocationPinProvider.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeLocationPinProvider.kt
@@ -21,12 +21,13 @@ import im.vector.app.features.home.room.detail.timeline.helper.LocationPinProvid
 import io.mockk.every
 import io.mockk.invoke
 import io.mockk.mockk
+import org.matrix.android.sdk.api.util.MatrixItem
 
 class FakeLocationPinProvider {
 
     val instance = mockk<LocationPinProvider>(relaxed = true)
 
-    fun givenCreateForUserId(userId: String, expectedDrawable: Drawable) {
-        every { instance.create(userId, captureLambda()) } answers { lambda<(Drawable) -> Unit>().invoke(expectedDrawable) }
+    fun givenCreateForMatrixItem(matrixItem: MatrixItem, expectedDrawable: Drawable) {
+        every { instance.create(matrixItem, captureLambda()) } answers { lambda<(Drawable) -> Unit>().invoke(expectedDrawable) }
     }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->

This change ensure that the user Avatar used in location Event rendering is the same avatar than the avatar of the user in the room. Previously the application was using the Avatar from the user profile, but it can happen that the profile is not loaded into the DB, and so the fallback avatar was used (with the userId first later). As a consequence, if the user has set a avatar just on the current room, it will also be used.

This PR also improves how the cache works in `LocationPinProvider`. Rely on Glide cache, limit size, and invalidate cache in case of error, then success retrieving avatar data. Also use `UserItem` for the cache key, to invalidate cache if user avatar / display name change. So this PR also fix a refresh issue if user change their avatar.

This PR also fix a rendering issue of the initial avatar when long clicking on a location Event.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
User user avatar in Location share Event.

Parity with Element Web.

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Have a room with 2 members Alice and Bob.
- Invite Charlie to the room, Charlie has a profile avatar
- Charlie share their location to the room.
- Without this change, Alice and Bob do not see Charlie's avatar in the location Event, because Charlie's profile is not loaded. Charlie avatar is correctly rendered at the sender details above the message.
- With this change, Charlies's avatar is correctly rendered on the map, since the sender avatar is known and is used to render the location Event

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/element-hq/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
