### PR TITLE
Normal text extra line space '\n' resolved

### DIFF
--- a/vector/src/main/java/im/vector/app/features/html/EventHtmlRenderer.kt
+++ b/vector/src/main/java/im/vector/app/features/html/EventHtmlRenderer.kt
@@ -178,7 +178,11 @@ class EventHtmlRenderer @Inject constructor(
                     .plus(text.getSpans(0, length, HtmlCodeSpan::class.java).filter { !it.isBlock }.toTypedArray())
                     .flatten()
 
-            if (spans.isEmpty()) return
+            if (spans.isEmpty()){
+                val normalText = textView.text.replace(Regex("""^.*?\n\n""")) { matchResult -> matchResult.value.replace("\n\n", "\n") }
+                textView.text = normalText
+                return
+            }
 
             spans.forEach { span ->
                 val start = text.getSpanStart(span)


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

In the "EventHtmlRenderer.kt" file under the "removeLeadingNewlineForInlineElement" function we have added an expression that removes extra line spaces from normal text as well. The solution under the function focuses only on the formatted text lines. After making changes to the same function, we were able to resolve for the normal text lines as well.

## Motivation and context

[(https://github.com/element-hq/element-android/issues/8764#issue-2144036397)]

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->



| Before ![Screenshot_20240220_125700_Element](https://github.com/element-hq/element-android/assets/160589727/85a63cdb-f728-4c3c-bffb-9a8f440ec0f7)| After ![Screenshot_20240221_121252_Element - dbg](https://github.com/element-hq/element-android/assets/160589727/88b5ca37-cbb6-4ab2-963b-9661bf8728ba)|
|-|-|



## Tests



<!-- Explain how you tested your development -->

- Cloned the element-android project 
- Added the changes (on the developer branch) and ran the project on a physical android device
- The changes were successfully reflected on the android device

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 13

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/element-hq/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
