### PR TITLE
Fix send button blinking with RTE

### DIFF
--- a/changelog.d/send_button_blinking.bugfix
+++ b/changelog.d/send_button_blinking.bugfix
@@ -1,0 +1,1 @@
+Fix send button blinking once for each character you are typing in RTE.


### PR DESCRIPTION
Add a small debounce operation in the `TextWatcher` so we don't process the temporary empty text triggered by the RTE.