### PR TITLE
Quick improvement for analytics reporting

### DIFF
--- a/vector/src/main/java/im/vector/app/features/analytics/AnalyticsTracker.kt
+++ b/vector/src/main/java/im/vector/app/features/analytics/AnalyticsTracker.kt
@@ -23,8 +23,11 @@ import im.vector.app.features.analytics.plan.UserProperties
 interface AnalyticsTracker {
     /**
      * Capture an Event.
+     *
+     * @param extraProperties Some extra properties to attach to the event, that are not part of the events definition
+     * (https://github.com/matrix-org/matrix-analytics-events/) and specific to this platform.
      */
-    fun capture(event: VectorAnalyticsEvent)
+    fun capture(event: VectorAnalyticsEvent, extraProperties: Map<String, String>? = null)
 
     /**
      * Track a displayed screen.

--- a/vector/src/main/java/im/vector/app/features/analytics/DecryptionFailureTracker.kt
+++ b/vector/src/main/java/im/vector/app/features/analytics/DecryptionFailureTracker.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.matrix.android.sdk.api.session.Session
 import org.matrix.android.sdk.api.session.crypto.MXCryptoError
 import org.matrix.android.sdk.api.session.room.timeline.TimelineEvent
 import javax.inject.Inject
@@ -36,7 +37,9 @@ private data class DecryptionFailure(
         val timeStamp: Long,
         val roomId: String,
         val failedEventId: String,
-        val error: MXCryptoError.ErrorType
+        val error: MXCryptoError.ErrorType,
+        // Was the current session cross signed verified at the time of the error
+        val isCrossSignedVerified: Boolean = false
 )
 private typealias DetailedErrorName = Pair<String, Error.Name>
 
@@ -75,11 +78,14 @@ class DecryptionFailureTracker @Inject constructor(
         scope.cancel()
     }
 
-    fun e2eEventDisplayedInTimeline(event: TimelineEvent) {
+    fun e2eEventDisplayedInTimeline(event: TimelineEvent, session: Session) {
         scope.launch(Dispatchers.Default) {
             val mCryptoError = event.root.mCryptoError
             if (mCryptoError != null) {
-                addDecryptionFailure(DecryptionFailure(clock.epochMillis(), event.roomId, event.eventId, mCryptoError))
+                val isVerified = session.cryptoService().crossSigningService().isCrossSigningVerified()
+                addDecryptionFailure(
+                        DecryptionFailure(clock.epochMillis(), event.roomId, event.eventId, mCryptoError, isVerified)
+                )
             } else {
                 removeFailureForEventId(event.eventId)
             }
@@ -115,7 +121,7 @@ class DecryptionFailureTracker @Inject constructor(
 
     private fun checkFailures() {
         val now = clock.epochMillis()
-        val aggregatedErrors: Map<DetailedErrorName, List<String>>
+        val aggregatedErrors: Map<DetailedErrorName, List<DecryptionFailure>>
         synchronized(failures) {
             val toReport = mutableListOf<DecryptionFailure>()
             failures.removeAll { failure ->
@@ -129,7 +135,7 @@ class DecryptionFailureTracker @Inject constructor(
             aggregatedErrors = toReport
                     .groupBy { it.error.toAnalyticsErrorName() }
                     .mapValues {
-                        it.value.map { it.failedEventId }
+                        it.value
                     }
         }
 
@@ -137,15 +143,17 @@ class DecryptionFailureTracker @Inject constructor(
             // there is now way to send the total/sum in posthog, so iterating
             aggregation.value
                     // for now we ignore events already reported even if displayed again?
-                    .filter { alreadyReported.contains(it).not() }
-                    .forEach { failedEventId ->
-                        analyticsTracker.capture(Error(
-                                context = aggregation.key.first,
-                                domain = Error.Domain.E2EE,
-                                name = aggregation.key.second,
-                                cryptoModule = currentModule
-                        ))
-                        alreadyReported.add(failedEventId)
+                    .filter { alreadyReported.contains(it.failedEventId).not() }
+                    .forEach { failure ->
+                        analyticsTracker.capture(
+                                Error(
+                                        context = aggregation.key.first,
+                                        domain = Error.Domain.E2EE,
+                                        name = aggregation.key.second,
+                                        cryptoModule = currentModule,
+                                ), mapOf("is_cross_signed_verified" to failure.isCrossSignedVerified.toString())
+                        )
+                        alreadyReported.add(failure.failedEventId)
                     }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/analytics/impl/DefaultVectorAnalytics.kt
+++ b/vector/src/main/java/im/vector/app/features/analytics/impl/DefaultVectorAnalytics.kt
@@ -90,6 +90,8 @@ class DefaultVectorAnalytics @Inject constructor(
         superProperties["appVersion"] = buildMeta.versionName
         // The appId (im.vector.app)
         superProperties["applicationId"] = buildMeta.applicationId
+        // The app flavor (GooglePlay, FDroid)
+        superProperties["appFlavor"] = buildMeta.flavorDescription
         // Parity with other platforms
         superProperties["cryptoSDK"] = "Rust"
     }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/TimelineItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/TimelineItemFactory.kt
@@ -159,7 +159,7 @@ class TimelineItemFactory @Inject constructor(
                     }
                 }.also {
                     if (it != null && event.isEncrypted()) {
-                        decryptionFailureTracker.e2eEventDisplayedInTimeline(event)
+                        decryptionFailureTracker.e2eEventDisplayedInTimeline(event, session)
                     }
                 }
             }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
Quick improvement on Analytics for posthog that would allow us to better filter reported decryption errors.

This is adding the following properties to all events:
`appVersion`: similar to what web is doing.
`applicationId`: the package id
`appFlavoe`: the flavor (googlePlay / FDroid)
`cryptoSDK`: Parity with web, to allow to use common filters.

Also adding a specific property for E2E domain errors, that are not common to all platforms (`is_cross_signed_verified`).

## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/element-hq/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
