### PR TITLE
Fix setup secure backup

### DIFF
--- a/changelog.d/8786.bugfix
+++ b/changelog.d/8786.bugfix
@@ -1,0 +1,1 @@
+ Fix infinite loading on secure backup setup ("Re-Authentication needed" bottom sheet).

--- a/vector/src/main/java/im/vector/app/features/crypto/recover/BootstrapReAuthFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/recover/BootstrapReAuthFragment.kt
@@ -21,6 +21,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
+import androidx.lifecycle.ViewModelProvider
 import com.airbnb.mvrx.parentFragmentViewModel
 import com.airbnb.mvrx.withState
 import dagger.hilt.android.AndroidEntryPoint
@@ -43,6 +44,12 @@ class BootstrapReAuthFragment :
 
         views.bootstrapRetryButton.debouncedClicks { submit() }
         views.bootstrapCancelButton.debouncedClicks { cancel() }
+
+        val viewModel = ViewModelProvider(this).get(BootstrapReAuthViewModel::class.java)
+        if (!viewModel.isFirstSubmitDone) {
+            viewModel.isFirstSubmitDone = true
+            submit()
+        }
     }
 
     private fun submit() = withState(sharedViewModel) { state ->

--- a/vector/src/main/java/im/vector/app/features/crypto/recover/BootstrapReAuthViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/recover/BootstrapReAuthViewModel.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.crypto.recover
+
+import androidx.lifecycle.ViewModel
+
+class BootstrapReAuthViewModel : ViewModel() {
+    var isFirstSubmitDone = false
+}


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
This PR contains 2 fixes:
- the first one (5cd78c02aacb697f2cfe19fead1b29a4e22d9f95) ensure that the keys displayed on screen are refresh as fast as possible after a reset key. Previously the user had to wait for the next sync response to see the displayed key change in this screen:

<img width="221" alt="image" src="https://github.com/element-hq/element-android/assets/3940906/ba2191ea-8438-4dca-85e9-43de96fbe259">

To reproduce, on this screen ^ click on "Reset Keys" and observe that as soon as the loading dialog is dimissed, the keys are updated on screen. Previously user had to wait at most 30s to see the update.

- The second fix (1155c43fe07c10e46e3e187b40b028bff30e04aa) ensures that when the `BootstrapReAuthFragment` is displayed, a first submit request is performed. Else an infinite loading wheel was displayed.

To reproduce the issue:
- create a new account on EA by selecting matrix.org (or another HS)
- when the account is created and the welcome screen is displayed (with action to personalize the account, and a "take me home button"), kill the app (do not go on the home screen for the moment).
- start the application again, a dialog "Encryption upgrade available" is displayed, if you click on it, a bottom sheet is opened with an infinite loading wheel.

With this PR, the infinite loading wheel is not displayed, and if necessary, the `ReAuthActivity` is launch, to either ask the user to enter their password or login again using SSO

I have tested OK the direct flow (i.e. without entering the password) and the flow with entering the password. To test this flow you have to wait for the grace period server side to expire (not sure what the grace period duration is on matrix.org).

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Fix infinite loading wheel.

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- See content above.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/element-hq/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
