### PR TITLE
Bump posthog version to 3.2.0

### DIFF
--- a/dependencies_groups.gradle
+++ b/dependencies_groups.gradle
@@ -120,7 +120,7 @@ ext.groups = [
                         'com.parse.bolts',
                         'com.pinterest',
                         'com.pinterest.ktlint',
-                        'com.posthog.android',
+                        'com.posthog',
                         'com.squareup',
                         'com.squareup.curtains',
                         'com.squareup.duktape',

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -231,9 +231,7 @@ dependencies {
     kapt libs.dagger.hiltCompiler
 
     // Analytics
-    implementation('com.posthog.android:posthog:2.0.3') {
-        exclude group: 'com.android.support', module: 'support-annotations'
-    }
+    implementation 'com.posthog:posthog-android:3.2.0'
     implementation libs.sentry.sentryAndroid
 
     // UnifiedPush

--- a/vector/src/main/java/im/vector/app/features/analytics/impl/PostHogFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/analytics/impl/PostHogFactory.kt
@@ -17,7 +17,9 @@
 package im.vector.app.features.analytics.impl
 
 import android.content.Context
-import com.posthog.android.PostHog
+import com.posthog.PostHogInterface
+import com.posthog.android.PostHogAndroid
+import com.posthog.android.PostHogAndroidConfig
 import im.vector.app.core.resources.BuildMeta
 import im.vector.app.features.analytics.AnalyticsConfig
 import javax.inject.Inject
@@ -28,29 +30,17 @@ class PostHogFactory @Inject constructor(
         private val buildMeta: BuildMeta,
 ) {
 
-    fun createPosthog(): PostHog {
-        return PostHog.Builder(context, analyticsConfig.postHogApiKey, analyticsConfig.postHogHost)
-                // Record certain application events automatically! (off/false by default)
-                // .captureApplicationLifecycleEvents()
-                // Record screen views automatically! (off/false by default)
-                // .recordScreenViews()
-                // Capture deep links as part of the screen call. (off by default)
-                // .captureDeepLinks()
-                // Maximum number of events to keep in queue before flushing (default 20)
-                // .flushQueueSize(20)
-                // Max delay before flushing the queue (30 seconds)
-                // .flushInterval(30, TimeUnit.SECONDS)
-                // Enable or disable collection of ANDROID_ID (true)
-                .collectDeviceId(false)
-                .logLevel(getLogLevel())
-                .build()
-    }
-
-    private fun getLogLevel(): PostHog.LogLevel {
-        return if (buildMeta.isDebug) {
-            PostHog.LogLevel.DEBUG
-        } else {
-            PostHog.LogLevel.INFO
+    fun createPosthog(): PostHogInterface {
+        val config = PostHogAndroidConfig(
+                apiKey = analyticsConfig.postHogApiKey,
+                host = analyticsConfig.postHogHost,
+                // we do that manually
+                captureScreenViews = false,
+        ).also {
+            if (buildMeta.isDebug) {
+                it.debug = true
+            }
         }
+        return PostHogAndroid.with(context, config)
     }
 }

--- a/vector/src/test/java/im/vector/app/test/fakes/FakePostHogFactory.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakePostHogFactory.kt
@@ -16,12 +16,12 @@
 
 package im.vector.app.test.fakes
 
-import com.posthog.android.PostHog
+import com.posthog.PostHogInterface
 import im.vector.app.features.analytics.impl.PostHogFactory
 import io.mockk.every
 import io.mockk.mockk
 
-class FakePostHogFactory(postHog: PostHog) {
+class FakePostHogFactory(postHog: PostHogInterface) {
     val instance = mockk<PostHogFactory>().also {
         every { it.createPosthog() } returns postHog
     }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
Bump posthog version to 3.2.0.
We were using a quite old posthog sdk. Updating to the new one mainly because it now support [`sessions`](https://posthog.com/docs/data/sessions). Allow us to have a per device view instead of only unique users that is merging events from all the devices of the same user.

## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/element-hq/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
