### PR TITLE
Fix redacted events not grouped correctly

### DIFF
--- a/changelog.d/8840.bugfix
+++ b/changelog.d/8840.bugfix
@@ -1,0 +1,1 @@
+Fix redacted events not grouped correctly when hidden events are inserted between.

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/helper/TimelineEventVisibilityHelper.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/helper/TimelineEventVisibilityHelper.kt
@@ -151,16 +151,20 @@ class TimelineEventVisibilityHelper @Inject constructor(
             rootThreadEventId: String?,
             isFromThreadTimeline: Boolean
     ): List<TimelineEvent> {
-        val prevSub = timelineEvents
-                .subList(0, index + 1)
-                // Ensure to not take the REDACTION events into account
-                .filter { it.root.getClearType() != EventType.REDACTION }
-        return prevSub
+        val prevDisplayableEvents = timelineEvents.subList(0, index + 1)
+                .filter {
+                    shouldShowEvent(
+                            timelineEvent = it,
+                            highlightedEventId = eventIdToHighlight,
+                            isFromThreadTimeline = isFromThreadTimeline,
+                            rootThreadEventId = rootThreadEventId)
+                }
+        return prevDisplayableEvents
                 .reversed()
                 .let {
                     nextEventsUntil(it, 0, minSize, eventIdToHighlight, rootThreadEventId, isFromThreadTimeline, object : PredicateToStopSearch {
                         override fun shouldStopSearch(oldEvent: Event, newEvent: Event): Boolean {
-                            return oldEvent.isRedacted() && !newEvent.isRedacted()
+                            return !newEvent.isRedacted()
                         }
                     })
                 }


### PR DESCRIPTION
Closes #8840

The algorithm was only checking for `m.room.redaction` but this could happen for any invisible events.