### PR TITLE
When sending user mentions, always send the user id as the fallback text

### DIFF
--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/session/room/send/MarkdownParserTest.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/session/room/send/MarkdownParserTest.kt
@@ -26,10 +26,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.MethodSorters
 import org.matrix.android.sdk.InstrumentedTest
-import org.matrix.android.sdk.api.MatrixConfiguration
 import org.matrix.android.sdk.api.util.TextContent
-import org.matrix.android.sdk.common.TestRoomDisplayNameFallbackProvider
-import org.matrix.android.sdk.internal.session.displayname.DisplayNameResolver
 import org.matrix.android.sdk.internal.session.room.send.pills.MentionLinkSpecComparator
 import org.matrix.android.sdk.internal.session.room.send.pills.TextPillsUtils
 
@@ -56,12 +53,6 @@ class MarkdownParserTest : InstrumentedTest {
             HtmlRenderer.builder().softbreak("<br />").build(),
             TextPillsUtils(
                     MentionLinkSpecComparator(),
-                    DisplayNameResolver(
-                            MatrixConfiguration(
-                                    applicationFlavor = "TestFlavor",
-                                    roomDisplayNameFallbackProvider = TestRoomDisplayNameFallbackProvider()
-                            )
-                    ),
                     TestPermalinkService()
             )
     )

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/send/pills/TextPillsUtils.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/send/pills/TextPillsUtils.kt
@@ -19,7 +19,6 @@ import android.text.SpannableString
 import org.matrix.android.sdk.api.session.permalinks.PermalinkService
 import org.matrix.android.sdk.api.session.room.send.MatrixItemSpan
 import org.matrix.android.sdk.api.util.MatrixItem
-import org.matrix.android.sdk.internal.session.displayname.DisplayNameResolver
 import java.util.Collections
 import javax.inject.Inject
 
@@ -29,7 +28,6 @@ import javax.inject.Inject
  */
 internal class TextPillsUtils @Inject constructor(
         private val mentionLinkSpecComparator: MentionLinkSpecComparator,
-        private val displayNameResolver: DisplayNameResolver,
         private val permalinkService: PermalinkService
 ) {
 
@@ -70,7 +68,7 @@ internal class TextPillsUtils @Inject constructor(
                 // append text before pill
                 append(text, currIndex, start)
                 // append the pill
-                append(String.format(template, urlSpan.matrixItem.id, displayNameResolver.getBestName(urlSpan.matrixItem)))
+                append(String.format(template, urlSpan.matrixItem.id, urlSpan.matrixItem.id))
                 currIndex = end
             }
             // append text after the last pill

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/AutoCompleter.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/AutoCompleter.kt
@@ -246,10 +246,10 @@ class AutoCompleter @AssistedInject constructor(
         val linkText = when (matrixItem) {
             is MatrixItem.RoomAliasItem,
             is MatrixItem.RoomItem,
-            is MatrixItem.SpaceItem ->
+            is MatrixItem.SpaceItem,
+            is MatrixItem.UserItem ->
                 matrixItem.id
             is MatrixItem.EveryoneInRoomItem,
-            is MatrixItem.UserItem,
             is MatrixItem.EventItem ->
                 matrixItem.getBestName()
         }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerFragment.kt
@@ -796,14 +796,14 @@ class MessageComposerFragment : VectorBaseFragment<FragmentComposerBinding>(), A
             composer.editText.setSelection(Command.EMOTE.command.length + 1)
         } else {
             val roomMember = timelineViewModel.getMember(userId)
-            val displayName = sanitizeDisplayName(roomMember?.displayName ?: userId)
             if ((composer as? RichTextComposerLayout)?.isTextFormattingEnabled == true) {
                 // Rich text editor is enabled so we need to use its APIs
                 permalinkService.createPermalink(userId)?.let { url ->
-                    (composer as RichTextComposerLayout).insertMention(url, displayName)
+                    (composer as RichTextComposerLayout).insertMention(url, userId)
                     composer.editText.append(" ")
                 }
             } else {
+                val displayName = sanitizeDisplayName(roomMember?.displayName ?: userId)
                 val pill = buildSpannedString {
                     append(displayName)
                     setSpan(


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

- Make sure the rich text editor and the markdown one both send mentions with the user id as the fallback text for the permalink.

## Motivation and context

Sending the user's display name can lead to other clients rendering outdated names or incorrect ones, so we'd rather fall back to the user id.

## Tests

<!-- Explain how you tested your development -->

Send user mentions with both the RTE enabled and disabled, check the formatted body contains user id as the link's fallback text.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/element-hq/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
