### PR TITLE
[Bugfix] Fix microphone loss during background voice calls on Android 14

### DIFF
--- a/library/ui-strings/src/main/res/values/strings.xml
+++ b/library/ui-strings/src/main/res/values/strings.xml
@@ -652,6 +652,8 @@
 
     <string name="call_remove_jitsi_widget_progress">Ending call…</string>
 
+    <string name="microphone_in_use_title">Microphone in use</string>
+
     <!-- permissions Android M -->
     <string name="permissions_rationale_popup_title">Information</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->

--- a/vector/src/main/AndroidManifest.xml
+++ b/vector/src/main/AndroidManifest.xml
@@ -395,6 +395,13 @@
             android:foregroundServiceType="mediaProjection"
             tools:targetApi="Q" />
 
+        <service
+            android:name=".features.call.audio.MicrophoneAccessService"
+            android:exported="false"
+            android:foregroundServiceType="microphone"
+            android:permission="android.permission.FOREGROUND_SERVICE_MICROPHONE">
+        </service>
+
         <!-- Receivers -->
 
         <receiver

--- a/vector/src/main/AndroidManifest.xml
+++ b/vector/src/main/AndroidManifest.xml
@@ -56,6 +56,9 @@
     <!-- Jitsi SDK is now API23+ -->
     <uses-sdk tools:overrideLibrary="com.swmansion.gesturehandler,org.jitsi.meet.sdk,com.oney.WebRTCModule,com.learnium.RNDeviceInfo,com.reactnativecommunity.asyncstorage,com.ocetnik.timer,com.calendarevents,com.reactnativecommunity.netinfo,com.kevinresol.react_native_default_preference,com.rnimmersive,com.rnimmersivemode,com.corbt.keepawake,com.BV.LinearGradient,com.horcrux.svg,com.oblador.performance,com.reactnativecommunity.slider,com.brentvatne.react,com.reactnativecommunity.clipboard,com.swmansion.gesturehandler.react,org.linusu,org.reactnative.maskedview,com.reactnativepagerview,com.swmansion.reanimated,com.th3rdwave.safeareacontext,com.swmansion.rnscreens,org.devio.rn.splashscreen,com.reactnativecommunity.webview,org.wonday.orientation" />
 
+    <!-- For MicrophoneAccessService -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
+
     <!-- Adding CAMERA permission prevents Chromebooks to see the application on the PlayStore -->
     <!-- Tell that the Camera is not mandatory to install the application -->
     <uses-feature

--- a/vector/src/main/java/im/vector/app/core/services/CallAndroidService.kt
+++ b/vector/src/main/java/im/vector/app/core/services/CallAndroidService.kt
@@ -31,6 +31,7 @@ import im.vector.app.core.extensions.singletonEntryPoint
 import im.vector.app.core.extensions.startForegroundCompat
 import im.vector.app.features.call.CallArgs
 import im.vector.app.features.call.VectorCallActivity
+import im.vector.app.features.call.audio.MicrophoneAccessService
 import im.vector.app.features.call.telecom.CallConnection
 import im.vector.app.features.call.webrtc.WebRtcCall
 import im.vector.app.features.call.webrtc.WebRtcCallManager
@@ -208,6 +209,9 @@ class CallAndroidService : VectorAndroidService() {
             stopForegroundCompat()
             mediaSession?.isActive = false
             myStopSelf()
+
+            // Also stop the microphone service if it is running
+            stopService(Intent(this, MicrophoneAccessService::class.java))
         }
         val wasConnected = connectedCallIds.remove(callId)
         if (!wasConnected && !terminatedCall.isOutgoing && !rejected && endCallReason != EndCallReason.ANSWERED_ELSEWHERE) {

--- a/vector/src/main/java/im/vector/app/features/call/audio/MicrophoneAccessService.kt
+++ b/vector/src/main/java/im/vector/app/features/call/audio/MicrophoneAccessService.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.call.audio
+
+import android.content.Intent
+import android.os.Binder
+import android.os.IBinder
+import dagger.hilt.android.AndroidEntryPoint
+import im.vector.app.core.extensions.startForegroundCompat
+import im.vector.app.core.services.VectorAndroidService
+import im.vector.app.features.notifications.NotificationUtils
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class MicrophoneAccessService : VectorAndroidService() {
+
+    @Inject lateinit var notificationUtils: NotificationUtils
+    private val binder = LocalBinder()
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        showMicrophoneAccessNotification()
+
+        return START_STICKY
+    }
+
+    private fun showMicrophoneAccessNotification() {
+        val notificationId = System.currentTimeMillis().toInt()
+        val notification = notificationUtils.buildMicrophoneAccessNotification()
+        startForegroundCompat(notificationId, notification)
+    }
+
+    override fun onBind(intent: Intent?): IBinder {
+        return binder
+    }
+
+    inner class LocalBinder : Binder() {
+        fun getService(): MicrophoneAccessService = this@MicrophoneAccessService
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/notifications/NotificationUtils.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotificationUtils.kt
@@ -539,6 +539,19 @@ class NotificationUtils @Inject constructor(
     }
 
     /**
+     * Creates a notification indicating that the microphone is currently being accessed by the application.
+     */
+    fun buildMicrophoneAccessNotification(): Notification {
+        return NotificationCompat.Builder(context, SILENT_NOTIFICATION_CHANNEL_ID)
+                .setContentTitle(stringProvider.getString(CommonStrings.microphone_in_use_title))
+                .setSmallIcon(R.drawable.ic_call_answer)
+                .setPriority(NotificationCompat.PRIORITY_LOW)
+                .setColor(ThemeUtils.getColor(context, android.R.attr.colorPrimary))
+                .setCategory(NotificationCompat.CATEGORY_CALL)
+                .build()
+    }
+
+    /**
      * Creates a notification that indicates the application is initializing.
      */
     fun buildStartAppNotification(): Notification {


### PR DESCRIPTION
Implemented a microphone access service to ensure uninterrupted microphone usage during voice calls, even when the app is running in the background.

Left photo represent when the call is in the background, and right when the app is open (no change in this case).
<img src="https://github.com/user-attachments/assets/144bc1ef-6d55-42e7-b959-c7f8f752d02c" alt="Screenshot_20240920_153509" width="300"/><img src="https://github.com/user-attachments/assets/f99d3004-a74d-46be-9e69-6ff5e408d9e4" alt="Screenshot_2
0240920_153721" width="300"/>

<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [X] Bugfix
- [ ] Technical
- [ ] Other :

## Content

This pull request fixes a bug where the app loses microphone access when it goes into the background during a voice call. The issue has been resolved by ensuring that microphone access is maintained during background operations and that the microphone service continues running as needed.

## Motivation and context

Issue: **App loses microphone access when not active on v 1.6.20 #8881**

Steps to reproduce:
1. Start a voice call.
2. Click the Home button or switch to another app.

**Expected outcome**:
The conversation should continue without interruptions, and the app should maintain access to the microphone even when switching to other apps or locking the phone.

**Actual outcome**:
The other party cannot hear the user because the app loses access to the microphone, which is indicated by the disappearance of the green dot on Samsung S24 devices.

Operating system: Android 14
App version: Element 1.6.20 (Google Play Store)

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

- Step 1: Reproduce the issue by placing a voice call and switching to another app.
- Step 2: Confirm that the microphone service continues to run and maintains access to the microphone after switching to the background.
- Step 3: Test that the microphone is properly stopped when the call is ended.
- Step 4: Ensure that the app works as expected on different devices with Android 14 and Android 12.

## Tested devices

- [X] Physical
- [X] Emulator
- OS version(s): Android 14, Android 12

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [X] Changes has been tested on an Android device or Android emulator with API 21
- [X] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [X] Pull request is based on the develop branch
- [X] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ X] Pull request includes screenshots or videos if containing UI changes
- [X] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [X] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/element-hq/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
