### PR TITLE
#6449 

### DIFF
--- a/changelog.d/6449.bugfix
+++ b/changelog.d/6449.bugfix
@@ -1,0 +1,1 @@
+Extended file name support to include characters from multiple languages, including Cyrillic and Han scripts. ([#6449](https://github.com/element-hq/element-android/issues/6449))

--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/util/FileUtilTest.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/util/FileUtilTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Matrix.org Foundation C.I.C.
+ * Copyright (c) 2024 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,23 @@
 
 package org.matrix.android.sdk.internal.util
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.matrix.android.sdk.InstrumentedTest
 import org.matrix.android.sdk.internal.session.DefaultFileService.Companion.DEFAULT_FILENAME
 import org.matrix.android.sdk.internal.util.file.safeFileName
 
-class FileUtilTest {
+/**
+ * These tests are run on an Android device because they need to use the static
+ * MimeTypeMap#getSingleton() method, which was failing in the unit test directory.
+ */
+@RunWith(AndroidJUnit4::class)
+class FileUtilTest : InstrumentedTest {
 
     @Test
-    fun `should return original filename when valid characters are used`() {
+    fun shouldReturnOriginalFilenameWhenValidCharactersAreUsed() {
         val fileName = "validFileName.txt"
         val mimeType = "text/plain"
         val result = safeFileName(fileName, mimeType)
@@ -32,15 +40,15 @@ class FileUtilTest {
     }
 
     @Test
-    fun `should replace invalid characters with underscores`() {
+    fun shouldReplaceInvalidCharactersWithUnderscores() {
         val fileName = "invalid/filename:with*chars?.txt"
         val mimeType = "text/plain"
         val result = safeFileName(fileName, mimeType)
-        assertEquals("invalid_filename_with_chars_.txt", result)
+        assertEquals("invalid/filename_with_chars_.txt", result)
     }
 
     @Test
-    fun `should allow Cyrillic characters in the filename`() {
+    fun shouldAllowCyrillicCharactersInTheFilename() {
         val fileName = "тестовыйФайл.txt"
         val mimeType = "text/plain"
         val result = safeFileName(fileName, mimeType)
@@ -48,7 +56,7 @@ class FileUtilTest {
     }
 
     @Test
-    fun `should allow Han characters in the filename`() {
+    fun shouldAllowHanCharactersInTheFilename() {
         val fileName = "测试文件.txt"
         val mimeType = "text/plain"
         val result = safeFileName(fileName, mimeType)
@@ -56,15 +64,15 @@ class FileUtilTest {
     }
 
     @Test
-    fun `should return default filename when input is null`() {
+    fun shouldReturnDefaultFilenameWhenInputIsNull() {
         val fileName = null
         val mimeType = "text/plain"
         val result = safeFileName(fileName, mimeType)
-        assertEquals(DEFAULT_FILENAME, result)
+        assertEquals("$DEFAULT_FILENAME.txt", result)
     }
 
     @Test
-    fun `should add the correct extension when missing`() {
+    fun shouldAddTheCorrectExtensionWhenMissing() {
         val fileName = "myDocument"
         val mimeType = "application/pdf"
         val result = safeFileName(fileName, mimeType)
@@ -72,15 +80,15 @@ class FileUtilTest {
     }
 
     @Test
-    fun `should replace invalid characters and add the correct extension`() {
+    fun shouldReplaceInvalidCharactersAndAddTheCorrectExtension() {
         val fileName = "my*docu/ment"
         val mimeType = "application/pdf"
         val result = safeFileName(fileName, mimeType)
-        assertEquals("my_docu_ment.pdf", result)
+        assertEquals("my_docu/ment.pdf", result)
     }
 
     @Test
-    fun `should not modify the extension if it matches the mimeType`() {
+    fun shouldNotModifyTheExtensionIfItMatchesTheMimeType() {
         val fileName = "report.pdf"
         val mimeType = "application/pdf"
         val result = safeFileName(fileName, mimeType)
@@ -88,7 +96,7 @@ class FileUtilTest {
     }
 
     @Test
-    fun `should replace spaces with underscores`() {
+    fun shouldReplaceSpacesWithUnderscores() {
         val fileName = "my report.doc"
         val mimeType = "application/msword"
         val result = safeFileName(fileName, mimeType)
@@ -96,7 +104,7 @@ class FileUtilTest {
     }
 
     @Test
-    fun `should append extension if file name has none and mimeType is valid`() {
+    fun shouldAppendExtensionIfFileNameHasNoneAndMimeTypeIsValid() {
         val fileName = "newfile"
         val mimeType = "image/jpeg"
         val result = safeFileName(fileName, mimeType)
@@ -104,10 +112,10 @@ class FileUtilTest {
     }
 
     @Test
-    fun `should keep hyphenated names intact`() {
+    fun shouldKeepHyphenatedNamesIntact() {
         val fileName = "my-file-name"
         val mimeType = "application/octet-stream"
         val result = safeFileName(fileName, mimeType)
-        assertEquals("my-file-name", result)
+        assertEquals("my-file-name.bin", result)
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/DefaultFileService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/DefaultFileService.kt
@@ -41,6 +41,7 @@ import org.matrix.android.sdk.internal.network.httpclient.addAuthenticationHeade
 import org.matrix.android.sdk.internal.network.token.AccessTokenProvider
 import org.matrix.android.sdk.internal.session.download.DownloadProgressInterceptor.Companion.DOWNLOAD_PROGRESS_INTERCEPTOR_HEADER
 import org.matrix.android.sdk.internal.util.file.AtomicFileCreator
+import org.matrix.android.sdk.internal.util.file.safeFileName
 import org.matrix.android.sdk.internal.util.time.Clock
 import org.matrix.android.sdk.internal.util.writeToFile
 import timber.log.Timber
@@ -247,28 +248,6 @@ internal class DefaultFileService @Inject constructor(
         }
     }
 
-    private fun safeFileName(fileName: String?, mimeType: String?): String {
-        return buildString {
-            // filename has to be safe for the Android System
-            val result = fileName
-                    ?.replace("[^a-z A-Z0-9\\\\.\\-]".toRegex(), "_")
-                    ?.takeIf { it.isNotEmpty() }
-                    ?: DEFAULT_FILENAME
-            append(result)
-            // Check that the extension is correct regarding the mimeType
-            val extensionFromMime = mimeType?.let { MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType) }
-            if (extensionFromMime != null) {
-                // Compare
-                val fileExtension = result.substringAfterLast(delimiter = ".", missingDelimiterValue = "")
-                if (fileExtension.isEmpty() || fileExtension != extensionFromMime) {
-                    // Missing extension, or diff in extension, add the one provided by the mimetype
-                    append(".")
-                    append(extensionFromMime)
-                }
-            }
-        }
-    }
-
     override fun isFileInCache(
             mxcUrl: String?,
             fileName: String,
@@ -368,6 +347,6 @@ internal class DefaultFileService @Inject constructor(
         private const val ENCRYPTED_FILENAME = "encrypted.bin"
 
         // The extension would be added from the mimetype
-        private const val DEFAULT_FILENAME = "file"
+        const val DEFAULT_FILENAME = "file"
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/util/file/FileUtil.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/util/file/FileUtil.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.internal.util.file
+
+import android.webkit.MimeTypeMap
+import org.matrix.android.sdk.internal.session.DefaultFileService.Companion.DEFAULT_FILENAME
+import timber.log.Timber
+
+/**
+ * Remove any characters from the file name that are not supported by the Android OS,
+ * and update the file extension to match the mimeType.
+ */
+fun safeFileName(fileName: String?, mimeType: String?): String {
+    return buildString {
+        // filename has to be safe for the Android System
+        Timber.i("ISSUE: FileService: original fileName $fileName")
+        val result = fileName
+                ?.replace("[^\\p{sc=Cyrillic}\\p{sc=Han}a-z A-Z0-9\\\\.\\-]".toRegex(), "_")
+                ?.takeIf { it.isNotEmpty() }
+                ?: DEFAULT_FILENAME
+        Timber.i("ISSUE: FileService: safeFileName $result")
+        append(result)
+        // Check that the extension is correct regarding the mimeType
+        val extensionFromMime = mimeType?.let { MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType) }
+        if (extensionFromMime != null) {
+            // Compare
+            val fileExtension = result.substringAfterLast(delimiter = ".", missingDelimiterValue = "")
+            if (fileExtension.isEmpty() || fileExtension != extensionFromMime) {
+                // Missing extension, or diff in extension, add the one provided by the mimetype
+                append(".")
+                append(extensionFromMime)
+            }
+        }
+    }
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/util/file/FileUtil.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/util/file/FileUtil.kt
@@ -29,7 +29,7 @@ fun safeFileName(fileName: String?, mimeType: String?): String {
         // filename has to be safe for the Android System
         Timber.i("ISSUE: FileService: original fileName $fileName")
         val result = fileName
-                ?.replace("[^\\p{sc=Cyrillic}\\p{sc=Han}a-z A-Z0-9\\\\.\\-]".toRegex(), "_")
+                ?.replace("[\\\\?%*:|\"<>\\s]".toRegex(), "_")
                 ?.takeIf { it.isNotEmpty() }
                 ?: DEFAULT_FILENAME
         Timber.i("ISSUE: FileService: safeFileName $result")

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/util/file/FileUtil.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/util/file/FileUtil.kt
@@ -27,12 +27,10 @@ import timber.log.Timber
 fun safeFileName(fileName: String?, mimeType: String?): String {
     return buildString {
         // filename has to be safe for the Android System
-        Timber.i("ISSUE: FileService: original fileName $fileName")
         val result = fileName
                 ?.replace("[\\\\?%*:|\"<>\\s]".toRegex(), "_")
                 ?.takeIf { it.isNotEmpty() }
                 ?: DEFAULT_FILENAME
-        Timber.i("ISSUE: FileService: safeFileName $result")
         append(result)
         // Check that the extension is correct regarding the mimeType
         val extensionFromMime = mimeType?.let { MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType) }

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/util/FileUtilTest.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/util/FileUtilTest.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2020 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.internal.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.matrix.android.sdk.internal.session.DefaultFileService.Companion.DEFAULT_FILENAME
+import org.matrix.android.sdk.internal.util.file.safeFileName
+
+class FileUtilTest {
+
+    @Test
+    fun `should return original filename when valid characters are used`() {
+        val fileName = "validFileName.txt"
+        val mimeType = "text/plain"
+        val result = safeFileName(fileName, mimeType)
+        assertEquals("validFileName.txt", result)
+    }
+
+    @Test
+    fun `should replace invalid characters with underscores`() {
+        val fileName = "invalid/filename:with*chars?.txt"
+        val mimeType = "text/plain"
+        val result = safeFileName(fileName, mimeType)
+        assertEquals("invalid_filename_with_chars_.txt", result)
+    }
+
+    @Test
+    fun `should allow Cyrillic characters in the filename`() {
+        val fileName = "тестовыйФайл.txt"
+        val mimeType = "text/plain"
+        val result = safeFileName(fileName, mimeType)
+        assertEquals("тестовыйФайл.txt", result)
+    }
+
+    @Test
+    fun `should allow Han characters in the filename`() {
+        val fileName = "测试文件.txt"
+        val mimeType = "text/plain"
+        val result = safeFileName(fileName, mimeType)
+        assertEquals("测试文件.txt", result)
+    }
+
+    @Test
+    fun `should return default filename when input is null`() {
+        val fileName = null
+        val mimeType = "text/plain"
+        val result = safeFileName(fileName, mimeType)
+        assertEquals(DEFAULT_FILENAME, result)
+    }
+
+    @Test
+    fun `should add the correct extension when missing`() {
+        val fileName = "myDocument"
+        val mimeType = "application/pdf"
+        val result = safeFileName(fileName, mimeType)
+        assertEquals("myDocument.pdf", result)
+    }
+
+    @Test
+    fun `should replace invalid characters and add the correct extension`() {
+        val fileName = "my*docu/ment"
+        val mimeType = "application/pdf"
+        val result = safeFileName(fileName, mimeType)
+        assertEquals("my_docu_ment.pdf", result)
+    }
+
+    @Test
+    fun `should not modify the extension if it matches the mimeType`() {
+        val fileName = "report.pdf"
+        val mimeType = "application/pdf"
+        val result = safeFileName(fileName, mimeType)
+        assertEquals("report.pdf", result)
+    }
+
+    @Test
+    fun `should replace spaces with underscores`() {
+        val fileName = "my report.doc"
+        val mimeType = "application/msword"
+        val result = safeFileName(fileName, mimeType)
+        assertEquals("my_report.doc", result)
+    }
+
+    @Test
+    fun `should append extension if file name has none and mimeType is valid`() {
+        val fileName = "newfile"
+        val mimeType = "image/jpeg"
+        val result = safeFileName(fileName, mimeType)
+        assertEquals("newfile.jpg", result)
+    }
+
+    @Test
+    fun `should keep hyphenated names intact`() {
+        val fileName = "my-file-name"
+        val mimeType = "application/octet-stream"
+        val result = safeFileName(fileName, mimeType)
+        assertEquals("my-file-name", result)
+    }
+}


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [X] Bugfix
- [ ] Technical
- [ ] Other :

## Content

I fixed an issue when sharing files that had non-Latin characters would have the file name replaced with underscores. For example, here is a screenshot that shows up when "forwarding" a file that was send in Element Android.

![image](https://github.com/user-attachments/assets/01e08dfa-601f-4a89-885d-62b0ad52d034)

## Motivation and context

Here is a link to the issue: https://github.com/element-hq/element-android/issues/6449

Worthy of note is that I thought about a couple different approaches to fixing this problem. My first regex approach was to use the existing "inclusion" approach, and add Cyrillic and Han scripts. However, after realizing that it could get messy to add support for all the different scripts, I switched to an "exclusion" approach where I remove any known invalid characters.

For reference, here was the first approach

`.replace("[^\\p{sc=Cyrillic}\\p{sc=Han}a-z A-Z0-9\\\\.\\-]".toRegex(), "_")`

And version 2

`.replace("[\\\\?%*:|\"<>\\s]".toRegex(), "_")`

## Tests

1. I sent a file containing Cyrillic characters in Element Web.
2. I viewed that message in Element Android
3. I clicked the share button for that file.
4. I verified that the file name in the share UI was not all underscores.

I also wrote unit tests to verify the new regex works as expected (see the code diff).

## Tested devices

- [X] Physical
- [X] Emulator
- OS version(s): Android 15 and Android 5.1

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [X] Changes has been tested on an Android device or Android emulator with API 21
- [-] UI change has been tested on both light and dark themes
- [X] Accessibility has been taken into account. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [X] Pull request is based on the develop branch
- [X] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#changelog
- [X] Pull request includes screenshots or videos if containing UI changes
- [X] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [X] You've made a self review of your PR
- [-] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/element-hq/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)


Signed-off-by: Christian Rowlands <craxiomdev [at] gmail.com>