### PR TITLE
#8865 Add a confirmation dialog for Report user functionality

### DIFF
--- a/changelog.d/8865.bugfix
+++ b/changelog.d/8865.bugfix
@@ -1,0 +1,1 @@
+Add a confirmation dialog of reporting the user.

--- a/changelog.d/8904.bugfix
+++ b/changelog.d/8904.bugfix
@@ -1,1 +1,0 @@
-Intercept mobile.element.io links with Element app

--- a/library/ui-strings/src/main/res/values/strings.xml
+++ b/library/ui-strings/src/main/res/values/strings.xml
@@ -707,6 +707,11 @@
     <string name="room_participants_action_unignore_prompt_msg">Unignoring this user will show all messages from them again.</string>
     <string name="room_participants_action_unignore">Unignore</string>
 
+    <string name="room_participants_action_report_title">Report user</string>
+    <string name="room_participants_action_report_prompt_msg">Reporting this user will report this user to the server administrators and room moderators.</string>
+    <string name="room_participants_action_report">Report</string>
+    <string name="room_participants_action_report_reason">Reporting user %1$s</string>
+
     <string name="room_participants_action_cancel_invite_title">Cancel invite</string>
     <string name="room_participants_action_cancel_invite_prompt_msg">Are you sure you want to cancel the invite for this user?</string>
     <string name="room_participants_remove_title">Remove user</string>

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
@@ -1877,11 +1877,7 @@ class TimelineFragment :
                 action.senderId?.let { askConfirmationToIgnoreUser(it) }
             }
             is EventSharedAction.ReportUser -> {
-                timelineViewModel.handle(
-                        RoomDetailAction.ReportContent(
-                                action.eventId, action.senderId, "Reporting user ${action.senderId}", user = true
-                        )
-                )
+                askConfirmationToReportUser(action.eventId, action.senderId)
             }
             is EventSharedAction.OnUrlClicked -> {
                 onUrlClicked(action.url, action.title)
@@ -1927,6 +1923,19 @@ class TimelineFragment :
                 .setNegativeButton(CommonStrings.action_cancel, null)
                 .setPositiveButton(CommonStrings.room_participants_action_ignore) { _, _ ->
                     timelineViewModel.handle(RoomDetailAction.IgnoreUser(senderId))
+                }
+                .show()
+    }
+
+    private fun askConfirmationToReportUser(eventId: String, senderId: String?) {
+        MaterialAlertDialogBuilder(requireContext(), im.vector.lib.ui.styles.R.style.ThemeOverlay_Vector_MaterialAlertDialog_Destructive)
+                .setTitle(CommonStrings.room_participants_action_report_title)
+                .setMessage(CommonStrings.room_participants_action_report_prompt_msg)
+                .setNegativeButton(CommonStrings.action_cancel, null)
+                .setPositiveButton(CommonStrings.room_participants_action_report) { _, _ ->
+                    timelineViewModel.handle(RoomDetailAction.ReportContent(
+                            eventId, senderId, getString(CommonStrings.room_participants_action_report_reason, senderId ), user = true
+                    ))
                 }
                 .show()
     }

--- a/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileFragment.kt
@@ -302,7 +302,17 @@ class RoomMemberProfileFragment :
     }
 
     override fun onReportClicked() {
-        viewModel.handle(RoomMemberProfileAction.ReportUser)
+        ConfirmationDialogBuilder
+                .show(
+                        activity = requireActivity(),
+                        askForReason = false,
+                        confirmationRes = CommonStrings.room_participants_action_report_prompt_msg,
+                        positiveRes = CommonStrings.room_participants_action_report,
+                        reasonHintRes = 0,
+                        titleRes = CommonStrings.room_participants_action_report_title
+                ) {
+                    viewModel.handle(RoomMemberProfileAction.ReportUser)
+                }
     }
 
     override fun onTapVerify() {


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

This PR add a confirmation dialog before reporting a user.

## Motivation and context

Fix and close #8865

## Screenshots / GIFs

![image](https://github.com/user-attachments/assets/753e25ef-805a-4838-9823-ecfc11ef7cf5)
![image](https://github.com/user-attachments/assets/90dbf993-05b8-4d63-b02b-6a2318cc8aa5)

## Tests

- In the room I pressed "Report user" button, then I confirm report
- In the "People" section in the room options I pressed "Report user" button, then confirm report

## Tested devices

- [x] Physical
- [x] Emulator
- OS version(s): Android 14 (API level 34)

## Checklist

- [] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [] Accessibility has been taken into account. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/element-hq/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
