### PR TITLE
Fix rendering text replies

### DIFF
--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/decorator/UpdatedReplyDecorator.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/decorator/UpdatedReplyDecorator.kt
@@ -59,7 +59,7 @@ internal class UpdatedReplyDecorator(
         val isRedactedEvent = timelineEventEntity.root?.asDomain()?.isRedacted() ?: false
 
         val replyText = localEchoEventFactory
-                .bodyForReply(currentTimelineEvent.getLastMessageContent(), true).formattedText ?: ""
+                .bodyForReply(currentTimelineEvent.getLastMessageContent(), true).takeFormatted()
 
         val newContent = localEchoEventFactory.createReplyTextContent(
                 timelineEventMapper.map(timelineEventEntity),


### PR DESCRIPTION
Reply fallbacks are about to go away completely (https://github.com/matrix-org/matrix-spec-proposals/pull/2781, https://github.com/element-hq/element-web/pull/28406) and Element will probably get a lot of complaints if rendering replies doesn't work correctly. According to @AmineI (in https://github.com/element-hq/element-android/issues/8162#issuecomment-2249178511) just switching `formattedText` to `takeFormatted()` may resolve the issue for text replies.

I haven't tested this myself. If the fix works, I assume the problem is that element was assuming `formatted_body` is always present, even though it's not required. To test: send `/plain text` as a reply using develop.element.io and ensure both the quote and reply text are visible in element android (the `/plain` should prevent `formatted_body` being added to the message).

Fixes #7445
Fixes #8162
Fixes #8460
Fixes #8866

Image replies will remain broken (#8432, #6570)