### PR TITLE
Ensure Realm migration does not crash

### DIFF
--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/migration/MigrateCryptoTo024.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/migration/MigrateCryptoTo024.kt
@@ -17,6 +17,7 @@
 package org.matrix.android.sdk.internal.crypto.store.db.migration
 
 import io.realm.DynamicRealm
+import org.matrix.android.sdk.internal.extensions.safeRemove
 import org.matrix.android.sdk.internal.util.database.RealmMigrator
 
 internal class MigrateCryptoTo024(realm: DynamicRealm) : RealmMigrator(realm, 24) {
@@ -32,20 +33,20 @@ internal class MigrateCryptoTo024(realm: DynamicRealm) : RealmMigrator(realm, 24
             get("CryptoRoomEntity")?.removeField("outboundSessionInfo")
 
             // Warning: order is important, first remove classes that depends on others.
-            remove("UserEntity")
-            remove("DeviceInfoEntity")
-            remove("CrossSigningInfoEntity")
-            remove("KeyInfoEntity")
-            remove("TrustLevelEntity")
-            remove("KeysBackupDataEntity")
-            remove("OlmInboundGroupSessionEntity")
-            remove("OlmSessionEntity")
-            remove("AuditTrailEntity")
-            remove("OutgoingKeyRequestEntity")
-            remove("KeyRequestReplyEntity")
-            remove("WithHeldSessionEntity")
-            remove("SharedSessionEntity")
-            remove("OutboundGroupSessionInfoEntity")
+            safeRemove("UserEntity")
+            safeRemove("DeviceInfoEntity")
+            safeRemove("CrossSigningInfoEntity")
+            safeRemove("KeyInfoEntity")
+            safeRemove("TrustLevelEntity")
+            safeRemove("KeysBackupDataEntity")
+            safeRemove("OlmInboundGroupSessionEntity")
+            safeRemove("OlmSessionEntity")
+            safeRemove("AuditTrailEntity")
+            safeRemove("OutgoingKeyRequestEntity")
+            safeRemove("KeyRequestReplyEntity")
+            safeRemove("WithHeldSessionEntity")
+            safeRemove("SharedSessionEntity")
+            safeRemove("OutboundGroupSessionInfoEntity")
         }
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/extensions/RealmExtensions.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/extensions/RealmExtensions.kt
@@ -19,6 +19,7 @@ package org.matrix.android.sdk.internal.extensions
 import io.realm.RealmList
 import io.realm.RealmObject
 import io.realm.RealmObjectSchema
+import io.realm.RealmSchema
 import org.matrix.android.sdk.internal.database.model.HomeServerCapabilitiesEntityFields
 import org.matrix.android.sdk.internal.util.fatalError
 
@@ -50,5 +51,11 @@ internal fun <T> RealmList<T>.clearWith(delete: (T) -> Unit) {
 internal fun RealmObjectSchema?.forceRefreshOfHomeServerCapabilities(): RealmObjectSchema? {
     return this?.transform { obj ->
         obj.setLong(HomeServerCapabilitiesEntityFields.LAST_UPDATED_TIMESTAMP, 0)
+    }
+}
+
+internal fun RealmSchema.safeRemove(className: String) {
+    if (get(className) != null) {
+        remove(className)
     }
 }


### PR DESCRIPTION
Fixes #8962. Not sure how to repro, maybe by migrating from an old DB version, but this PR is adding safety on the removal by checking that the class exists first.