### PR TITLE
#8964 Fix app crash on incoming call when running Android 14+

### DIFF
--- a/changelog.d/8964.bugfix
+++ b/changelog.d/8964.bugfix
@@ -1,0 +1,1 @@
+Fix incoming call crash on Android 14+. ([#8964](https://github.com/element-hq/element-android/issues/8964))

--- a/vector/src/main/java/im/vector/app/features/call/VectorCallActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/call/VectorCallActivity.kt
@@ -246,9 +246,16 @@ class VectorCallActivity :
                 == PackageManager.PERMISSION_GRANTED) {
             // Only start the service if the app is in the foreground
             if (isAppInForeground()) {
-                Timber.tag(loggerTag.value).v("Starting microphone foreground service")
-                val intent = Intent(this, MicrophoneAccessService::class.java)
-                ContextCompat.startForegroundService(this, intent)
+                // Starting in Android 14, you can't create a microphone foreground service while your app is in
+                // the background. If we call startForegroundService the app will crash.
+                // https://github.com/element-hq/element-android/issues/8964
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                    Timber.tag(loggerTag.value).v("Starting microphone foreground service")
+                    val intent = Intent(this, MicrophoneAccessService::class.java)
+                    ContextCompat.startForegroundService(this, intent)
+                } else {
+                    Timber.tag(loggerTag.value).v("App is in running Android 14+; cannot start microphone service")
+                }
             } else {
                 Timber.tag(loggerTag.value).v("App is not in foreground; cannot start microphone service")
             }

--- a/vector/src/main/java/im/vector/app/features/call/VectorCallActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/call/VectorCallActivity.kt
@@ -253,7 +253,7 @@ class VectorCallActivity :
                     // already been answered before starting the MicrophoneAccessService
                     // https://github.com/element-hq/element-android/issues/8964
                     val callState = it.callState.invoke()
-                    if (callState !is CallState.LocalRinging && callState !is CallState.Ended) {
+                    if (callState !is CallState.LocalRinging && callState !is CallState.Ended && callState != null) {
                         Timber.tag(loggerTag.value).v("Starting microphone foreground service")
                         val intent = Intent(this, MicrophoneAccessService::class.java)
                         ContextCompat.startForegroundService(this, intent)


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [X] Bugfix
- [ ] Technical
- [ ] Other :

## Content

I removed the call to start the MicrophoneAccessService on Android 14+.

## Motivation and context

This change is in response to this GitHub Issue: https://github.com/element-hq/element-android/issues/8964

When running on Android 14+, if you have the microphone permission granted to the app, incoming calls while the app is in the background causes the app to crash, and the incoming call to not come through. The Android documentation for that is here: https://developer.android.com/develop/background-work/services/fgs/service-types#microphone

and here: https://developer.android.com/develop/background-work/services/fgs/restrictions-bg-start#wiu-restrictions

## Tests

I tested by making a call to a device running Android 14 and my changes while the device is locked, as well as unlocked with the app open.

## Tested devices

- [X] Physical
- [ ] Emulator
- OS version(s): Android 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ - ] Changes has been tested on an Android device or Android emulator with API 21
- [ - ] UI change has been tested on both light and dark themes
- [ - ] Accessibility has been taken into account. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [X] Pull request is based on the develop branch
- [X] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ - ] Pull request includes screenshots or videos if containing UI changes
- [X] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [X] You've made a self review of your PR
- [ - ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/element-hq/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)

Signed-off-by: Christian Rowlands <craxiomdev [at] gmail.com>