### PR TITLE
Filter mobile link

### DIFF
--- a/changelog.d/9033.misc
+++ b/changelog.d/9033.misc
@@ -1,0 +1,1 @@
+Filter mobile links: only open links which have an explicit empty path like `https://mobile.element.io/?hs_url=...`

--- a/tools/tests/test_configuration_link.sh
+++ b/tools/tests/test_configuration_link.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-adb shell am start -a android.intent.action.VIEW -d "https://mobile.element.io?hs_url=https%3A%2F%2Fmozilla-test.modular.im"
+adb shell am start -a android.intent.action.VIEW -d "https://mobile.element.io?hs_url=https%3A%2F%2Felement.io"

--- a/tools/tests/test_configuration_link.sh
+++ b/tools/tests/test_configuration_link.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-adb shell am start -a android.intent.action.VIEW -d "https://mobile.element.io?hs_url=https%3A%2F%2Felement.io"
+adb shell am start -a android.intent.action.VIEW -d "https://mobile.element.io/?hs_url=https%3A%2F%2Felement.io"

--- a/vector/src/main/AndroidManifest.xml
+++ b/vector/src/main/AndroidManifest.xml
@@ -206,8 +206,17 @@
                 <data android:host="develop.element.io" />
                 <!-- Matching asset file: https://staging.element.io/.well-known/assetlinks.json -->
                 <data android:host="staging.element.io" />
-                <!-- Fix it https://github.com/element-hq/element-android/issues/8904 -->
+            </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="https" />
                 <data android:host="mobile.element.io" />
+                <!-- accept only root path -->
+                <data android:path="/" />
             </intent-filter>
         </activity>
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->

Accept only root path on mobile.element.io link, to prevent Element Android to intercept link that are for Element X Android or Element Pro.

Note that the link must contain the path `/` like this:
- https://mobile.element.io/?hs_url=https%3A%2F%2Felement.io

Without it, i.e.:
- https://mobile.element.io?hs_url=https%3A%2F%2Felement.io

Element Android will not handle the link and it will be opened in the browser.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Ensure the targeted application open the link and not another one.

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->
NA

## Tests

<!-- Explain how you tested your development -->

- Install the app
- Run the script `tools/tests/test_configuration_link.sh`
- Ensure that Element Android is started and not another app or the browser
- Click on "SIGN IN"
- Ensure that the default account provider is `element.io`

<img width="270" alt="image" src="https://github.com/user-attachments/assets/ae08c1b8-7b28-4587-b848-cec41afab9fc" />


## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/element-hq/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
