### PR TITLE
Use ubuntu-22.04 runner instead of buildjet for the UI tests

### DIFF
--- a/.github/workflows/post-pr.yml
+++ b/.github/workflows/post-pr.yml
@@ -31,7 +31,7 @@ jobs:
   ui-tests:
     name: UI Tests (Synapse)
     needs: should-i-run
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-22.04
     timeout-minutes: 90 # We might need to increase it if the time for tests grows
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   tests:
     name: Runs all tests
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-22.04
     timeout-minutes: 90 # We might need to increase it if the time for tests grows
     strategy:
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,11 +1,7 @@
 name: Test
 
 on:
-  pull_request: { }
-  push:
-    branches: [ main, develop ]
-    paths-ignore:
-      - '.github/**'
+  workflow_dispatch:
 
 # Enrich gradle.properties for CI/CD
 env:


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

- Remove the BuildJet runner from our CI jobs.
- Make the UI test one run only after merging PRs or manually for a branch, since it's not really maintained.

## Motivation and context

We want to get rid of the BuildJet runners.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/element-hq/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
