### PR TITLE
Strip trailing whitespace from log lines

### DIFF
--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/OlmMachine.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/OlmMachine.kt
@@ -95,7 +95,7 @@ import org.matrix.rustcomponents.sdk.crypto.ProgressListener as RustProgressList
 
 class CryptoLogger : Logger {
     override fun log(logLine: String) {
-        Timber.d(logLine)
+        Timber.d(logLine.trimEnd())
     }
 }
 


### PR DESCRIPTION
Log lines coming from the Rust SDK have a trailing newline, meaning that when we emit them, we get a blank line in the logs. To prevent this, strip off trailing whitespace.