### PR TITLE
Bump Jitsi to v 11.4.0 with 16KB page size

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ allprojects {
         }
         // Jitsi repo
         maven {
-            url "https://github.com/element-hq/jitsi_libre_maven/raw/main/mobile-sdk-10.2.0"
+            url "https://github.com/element-hq/jitsi_libre_maven/raw/main/mobile-sdk-11.4.0"
             // Note: to test Jitsi release you can use a local file like this:
             // url "file:///Users/bmarty/workspaces/jitsi_libre_maven/mobile-sdk-10.2.0"
             content {

--- a/changelog.d/9080.misc
+++ b/changelog.d/9080.misc
@@ -1,0 +1,1 @@
+Bump Jitsi to v 11.4.0 with 16KB page size - bump minSdk to 26.

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,5 @@
 ext.versions = [
-        'minSdk'            : 26,
+        'minSdk'            : 21,
         'compileSdk'        : 35,
         'targetSdk'         : 35,
         'sourceCompat'      : JavaVersion.VERSION_21,

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,5 @@
 ext.versions = [
-        'minSdk'            : 21,
+        'minSdk'            : 26,
         'compileSdk'        : 35,
         'targetSdk'         : 35,
         'sourceCompat'      : JavaVersion.VERSION_21,

--- a/library/ui-strings/src/main/res/values-ar/strings.xml
+++ b/library/ui-strings/src/main/res/values-ar/strings.xml
@@ -82,8 +82,6 @@
     <string name="notice_widget_modified_by_you">عدَّلتَ ودجة %1$s</string>
     <string name="power_level_admin">مدير</string>
     <string name="power_level_default">الاِفتراضي</string>
-    <string name="power_level_custom">مُخصَّص (⁨%1$d⁩)</string>
-    <string name="power_level_custom_no_value">مخصَّص</string>
     <string name="notice_power_level_changed_by_you">غيَّرتَ مُستوى سلطة %1$s.</string>
     <string name="notice_power_level_changed">غيَّرَ %1$s مُستوى سلطة %2$s.</string>
     <string name="notice_power_level_diff">%1$s مِن %2$s إلى %3$s</string>
@@ -981,7 +979,6 @@
     <string name="room_member_power_level_admin_in">مدير لـ %1$s</string>
     <string name="room_member_power_level_users">المستخدمون</string>
     <string name="room_member_power_level_invites">الدعوات</string>
-    <string name="room_member_power_level_custom">مخصص</string>
     <string name="room_member_power_level_moderators">المشرفون</string>
     <string name="room_member_power_level_admins">المديرون</string>
     <string name="room_profile_leaving_room">يغادر الغرفة.…</string>

--- a/library/ui-strings/src/main/res/values-az/strings.xml
+++ b/library/ui-strings/src/main/res/values-az/strings.xml
@@ -230,8 +230,6 @@
     <string name="notice_power_level_diff">%1$s, %2$s - %3$s</string>
     <string name="notice_power_level_changed">%1$s, %2$s üçün güc səviyyəsini dəyişdi.</string>
     <string name="notice_power_level_changed_by_you">Siz %1$s üçün güc səviyyəsini dəyişdirdiniz.</string>
-    <string name="power_level_custom_no_value">Xüsusi</string>
-    <string name="power_level_custom">Fərdi (%1$d)</string>
     <string name="power_level_default">Defolt</string>
     <string name="power_level_moderator">Münsif</string>
     <string name="power_level_admin">Müdir</string>

--- a/library/ui-strings/src/main/res/values-bg/strings.xml
+++ b/library/ui-strings/src/main/res/values-bg/strings.xml
@@ -129,8 +129,6 @@
     <string name="notice_power_level_diff">%1$s от %2$s на %3$s</string>
     <string name="notice_power_level_changed">%1$s промени нивото на достъп на %2$s.</string>
     <string name="notice_power_level_changed_by_you">Променихте нивото на достъп на %1$s.</string>
-    <string name="power_level_custom_no_value">Собствено ниво</string>
-    <string name="power_level_custom">Собствено ниво (%1$d)</string>
     <string name="power_level_default">По подразбиране</string>
     <string name="power_level_moderator">Модератор</string>
     <string name="power_level_admin">Администратор</string>
@@ -1227,13 +1225,11 @@
     <string name="rendering_event_error_exception">${app_name} срещна проблем опитвайки се да визуализира съдържанието на събитие с идентификатор \'%1$s\'</string>
     <string name="rendering_event_error_type_of_event_not_handled">${app_name} не може да обработва събития от тип \'%1$s\'</string>
     <string name="room_member_jump_to_read_receipt">Отиди на последното прочетено съобщение</string>
-    <string name="room_member_power_level_custom_in">Собствено ниво (%1$d) в %2$s</string>
     <string name="room_member_power_level_default_in">По подразбиране в %1$s</string>
     <string name="room_member_power_level_moderator_in">Модератор в %1$s</string>
     <string name="room_member_power_level_admin_in">Администратор в %1$s</string>
     <string name="room_member_power_level_users">Потребители</string>
     <string name="room_member_power_level_invites">Поканени</string>
-    <string name="room_member_power_level_custom">Собствено ниво</string>
     <string name="room_member_power_level_moderators">Модератори</string>
     <string name="room_member_power_level_admins">Администратори</string>
     <string name="room_profile_leaving_room">Напускане на стаята…</string>

--- a/library/ui-strings/src/main/res/values-bn-rBD/strings.xml
+++ b/library/ui-strings/src/main/res/values-bn-rBD/strings.xml
@@ -701,8 +701,6 @@
     <string name="notice_power_level_diff">%1$s %2$s থেকে %3$s পর্যন্ত</string>
     <string name="notice_power_level_changed">%1$s %2$s এর পাওয়ার স্তর পরিবর্তন করেছে।</string>
     <string name="notice_power_level_changed_by_you">আপনি %1$s এর পাওয়ার স্তর পরিবর্তন করেছেন।</string>
-    <string name="power_level_custom_no_value">কাস্টম</string>
-    <string name="power_level_custom">কাস্টম (%1$d)</string>
     <string name="power_level_default">ডিফল্ট</string>
     <string name="power_level_moderator">নিয়ামক</string>
     <string name="power_level_admin">অ্যাডমিন</string>

--- a/library/ui-strings/src/main/res/values-bn-rIN/strings.xml
+++ b/library/ui-strings/src/main/res/values-bn-rIN/strings.xml
@@ -75,8 +75,6 @@
     <string name="power_level_admin">অ্যাডমিন</string>
     <string name="power_level_moderator">নিয়ামক</string>
     <string name="power_level_default">ডিফল্ট</string>
-    <string name="power_level_custom">কাস্টম (%1$d)</string>
-    <string name="power_level_custom_no_value">কাস্টম</string>
     <string name="notice_power_level_changed_by_you">আপনি %1$s এর পাওয়ার স্তর পরিবর্তন করেছেন।</string>
     <string name="notice_power_level_changed">%1$s %2$s এর পাওয়ার স্তর পরিবর্তন করেছে।</string>
     <string name="notice_power_level_diff">%1$s %2$s থেকে %3$s পর্যন্ত</string>

--- a/library/ui-strings/src/main/res/values-ca/strings.xml
+++ b/library/ui-strings/src/main/res/values-ca/strings.xml
@@ -128,8 +128,6 @@
     <string name="notice_power_level_diff">%1$s de %2$s a %3$s</string>
     <string name="notice_power_level_changed">%1$s ha canviat el nivell d\'autoritat de %2$s.</string>
     <string name="notice_power_level_changed_by_you">Has canviat el nivell d\'autoritat de %1$s.</string>
-    <string name="power_level_custom_no_value">Personalitzat</string>
-    <string name="power_level_custom">Personalitzat (%1$d)</string>
     <string name="power_level_default">Predeterminat</string>
     <string name="power_level_moderator">Moderador</string>
     <string name="power_level_admin">Administrador</string>
@@ -1382,13 +1380,11 @@
     <string name="room_widget_permission_avatar_url">URL de la teva foto</string>
     <string name="power_level_title">Rol</string>
     <string name="power_level_edit_title">Defineix rol</string>
-    <string name="room_member_power_level_custom_in">Personalitzat (%1$d) a %2$s</string>
     <string name="room_member_power_level_default_in">Predeterminat a %1$s</string>
     <string name="room_member_power_level_moderator_in">Moderador a %1$s</string>
     <string name="room_member_power_level_admin_in">Administrador a %1$s</string>
     <string name="room_member_power_level_users">Usuaris</string>
     <string name="room_member_power_level_invites">Invitacions</string>
-    <string name="room_member_power_level_custom">Personalitzat</string>
     <string name="room_member_power_level_moderators">Moderadors</string>
     <string name="room_member_power_level_admins">Administradors</string>
     <string name="room_widget_webview_read_protected_media">Llegeix mitjans protegits amb DRM</string>

--- a/library/ui-strings/src/main/res/values-cs/strings.xml
+++ b/library/ui-strings/src/main/res/values-cs/strings.xml
@@ -103,8 +103,6 @@
     <string name="power_level_admin">Správce</string>
     <string name="power_level_moderator">Moderátor</string>
     <string name="power_level_default">Výchozí</string>
-    <string name="power_level_custom">Vlastní (%1$d)</string>
-    <string name="power_level_custom_no_value">Vlastní</string>
     <string name="notice_power_level_changed_by_you">Změnili jste %1$s stupeň oprávnění.</string>
     <string name="notice_power_level_changed">%1$s změnil(a) %2$s stupeň oprávnění.</string>
     <string name="notice_power_level_diff">%1$s z %2$s na %3$s</string>
@@ -1269,12 +1267,10 @@
     <string name="room_profile_leaving_room">Opouštím místnost…</string>
     <string name="room_member_power_level_admins">Správci</string>
     <string name="room_member_power_level_moderators">Moderátoři</string>
-    <string name="room_member_power_level_custom">Vlastní</string>
     <string name="room_member_power_level_invites">Pozvánky</string>
     <string name="room_member_power_level_users">Uživatelé</string>
     <string name="room_member_power_level_admin_in">Správce v %1$s</string>
     <string name="room_member_power_level_moderator_in">Moderátor v %1$s</string>
-    <string name="room_member_power_level_custom_in">Vlastní (%1$d) in %2$s</string>
     <string name="room_member_jump_to_read_receipt">Přeskočit k potvrzení přečtení</string>
     <string name="rendering_event_error_type_of_event_not_handled">${app_name} neobstarává události typu \'%1$s\'</string>
     <string name="rendering_event_error_exception">${app_name} narazil na chybu při převádění obsahu události s id \'%1$s\'</string>

--- a/library/ui-strings/src/main/res/values-de/strings.xml
+++ b/library/ui-strings/src/main/res/values-de/strings.xml
@@ -124,8 +124,6 @@
     <string name="power_level_admin">Administrator</string>
     <string name="power_level_moderator">Moderator</string>
     <string name="power_level_default">Standard</string>
-    <string name="power_level_custom">Benutzerdefiniert (%1$d)</string>
-    <string name="power_level_custom_no_value">Benutzerdefiniert</string>
     <string name="notice_power_level_changed_by_you">Du hast die Berechtigungsstufe von %1$s geändert.</string>
     <string name="notice_power_level_changed">%1$s hat die Berechtigungsstufe von %2$s geändert.</string>
     <string name="notice_power_level_diff">%1$s von %2$s zu %3$s</string>
@@ -1247,7 +1245,6 @@
     <string name="room_profile_leaving_room">Verlasse den Raum …</string>
     <string name="room_member_power_level_admins">Administratoren</string>
     <string name="room_member_power_level_moderators">Moderatoren</string>
-    <string name="room_member_power_level_custom">Benutzerdefiniert</string>
     <string name="room_member_power_level_invites">Eingeladen</string>
     <string name="room_member_power_level_users">Benutzer</string>
     <string name="room_member_power_level_admin_in">Administrator in %1$s</string>
@@ -1330,7 +1327,6 @@
     <string name="event_redacted_by_admin_reason_with_reason">Ereignis vom Raumadministrator moderiert, Grund: %1$s</string>
     <string name="keys_backup_restore_success_title_already_up_to_date">Schlüssel sind bereits aktuell!</string>
     <string name="spoiler">Spoiler</string>
-    <string name="room_member_power_level_custom_in">Benutzerdefiniert (%1$d) in %2$s</string>
     <string name="login_default_session_public_name">${app_name} Android</string>
     <string name="settings_key_requests">Schlüsselanforderungen</string>
     <string name="e2e_use_keybackup">Schalte den verschlüsselten Nachrichtenverlauf frei</string>

--- a/library/ui-strings/src/main/res/values-el/strings.xml
+++ b/library/ui-strings/src/main/res/values-el/strings.xml
@@ -477,8 +477,6 @@
     <string name="notice_room_topic_removed_by_you">Έχεις αφαιρέσει το θέμα του δωματίου</string>
     <string name="notice_room_third_party_registered_invite_by_you">Αποδέχτηκες την πρόσκληση για το %1$s</string>
     <string name="power_level_default">Προεπιλογή</string>
-    <string name="power_level_custom">Custom (%1$d)</string>
-    <string name="power_level_custom_no_value">Προσαρμοσμένο</string>
     <string name="notice_room_server_acl_allow_is_empty">🎉Όλοι οι Servers έχουν αποκλειστεί από συμμετέχοντες!Το δωμάτιο αυτό δεν μπορεί πια να χρησιμοποιηθεί.</string>
     <string name="notice_room_third_party_invite_by_you">Έστειλες μια πρόσκληση στο %1$s για να συνδεθείς στο δωμάτιο</string>
     <string name="event_status_sent_message">Το μήνυμα στάλθηκε</string>

--- a/library/ui-strings/src/main/res/values-eo/strings.xml
+++ b/library/ui-strings/src/main/res/values-eo/strings.xml
@@ -119,9 +119,7 @@
     <string name="notice_room_invite_with_reason_by_you">Vi invitis uzanton %1$s. Kialo: %2$s</string>
     <string name="notice_room_invite_no_invitee_with_reason_by_you">Via invito. Kialo: %1$s</string>
     <string name="notice_power_level_diff">%1$s de %2$s al %3$s</string>
-    <string name="power_level_custom_no_value">Propra</string>
     <string name="power_level_default">Defaŭlta</string>
-    <string name="power_level_custom">Propra (%1$d)</string>
     <string name="power_level_moderator">Kontrolanto</string>
     <string name="power_level_admin">Administranto</string>
     <string name="notice_widget_modified_by_you">Vi ŝanĝis la fenestraĵon %1$s</string>
@@ -443,13 +441,11 @@
     <string name="rendering_event_error_exception">${app_name} renkontis problemon bildigante enhavon de okazo kun la identigilo «%1$s»</string>
     <string name="rendering_event_error_type_of_event_not_handled">${app_name} ne traktas okazojn de speco «%1$s»</string>
     <string name="room_member_jump_to_read_receipt">Salti al legokonfirmo</string>
-    <string name="room_member_power_level_custom_in">Propra (%1$d) en %2$s</string>
     <string name="room_member_power_level_default_in">Defaŭlto en %1$s</string>
     <string name="room_member_power_level_moderator_in">Kontrolanto en %1$s</string>
     <string name="room_member_power_level_admin_in">Administranto en %1$s</string>
     <string name="room_member_power_level_users">Uzantoj</string>
     <string name="room_member_power_level_invites">Invitoj</string>
-    <string name="room_member_power_level_custom">Propra</string>
     <string name="room_member_power_level_moderators">Kontrolantoj</string>
     <string name="room_member_power_level_admins">Administrantoj</string>
     <string name="room_profile_leaving_room">Forirante de ĉambro…</string>

--- a/library/ui-strings/src/main/res/values-es/strings.xml
+++ b/library/ui-strings/src/main/res/values-es/strings.xml
@@ -125,8 +125,6 @@
     <string name="power_level_admin">Administrador</string>
     <string name="power_level_moderator">Moderador</string>
     <string name="power_level_default">Por defecto</string>
-    <string name="power_level_custom">Personalizado (%1$d)</string>
-    <string name="power_level_custom_no_value">Personalizado</string>
     <string name="notice_power_level_changed_by_you">Cambiaste el nivel de permisos de %1$s.</string>
     <string name="notice_power_level_changed">%1$s cambió el nivel de permisos de %2$s.</string>
     <string name="notice_power_level_diff">%1$s de %2$s a %3$s</string>
@@ -1210,13 +1208,11 @@
     <string name="room_profile_leaving_room">Saliendo de la sala…</string>
     <string name="room_member_power_level_admins">Administradores</string>
     <string name="room_member_power_level_moderators">Moderadores</string>
-    <string name="room_member_power_level_custom">Nivel Personalizado</string>
     <string name="room_member_power_level_invites">Invitados</string>
     <string name="room_member_power_level_users">Usuarios</string>
     <string name="room_member_power_level_admin_in">Administrador en %1$s</string>
     <string name="room_member_power_level_moderator_in">Moderador en %1$s</string>
     <string name="room_member_power_level_default_in">Nivel Personalizado en %1$s</string>
-    <string name="room_member_power_level_custom_in">Nivel Personalizado (%1$d) en %2$s</string>
     <string name="room_member_jump_to_read_receipt">Saltar para leer el recibo</string>
     <string name="rendering_event_error_type_of_event_not_handled">${app_name} no maneja eventos de tipo \'%1$s\'</string>
     <string name="rendering_event_error_exception">${app_name} encontró un problema al representar el contenido del evento con el ID \'%1$s\'</string>

--- a/library/ui-strings/src/main/res/values-et/strings.xml
+++ b/library/ui-strings/src/main/res/values-et/strings.xml
@@ -124,8 +124,6 @@
     <string name="power_level_admin">Peakasutaja</string>
     <string name="power_level_moderator">Moderaator</string>
     <string name="power_level_default">Tavakasutaja</string>
-    <string name="power_level_custom">Kohandatud kasutajaõigused (%1$d)</string>
-    <string name="power_level_custom_no_value">Kohandatud õigused</string>
     <string name="notice_power_level_changed_by_you">Sina muutsid kasutaja %1$s õigusi.</string>
     <string name="notice_power_level_changed">%1$s muutis kasutaja %2$s õigusi.</string>
     <string name="notice_power_level_diff">%1$s õiguste muutus %2$s -&gt; %3$s</string>
@@ -1543,13 +1541,11 @@
     <string name="room_profile_leaving_room">Lahkun jututoast…</string>
     <string name="room_member_power_level_admins">Haldajad</string>
     <string name="room_member_power_level_moderators">Moderaatorid</string>
-    <string name="room_member_power_level_custom">Kohandatud õigused</string>
     <string name="room_member_power_level_invites">Kutsed</string>
     <string name="room_member_power_level_users">Kasutajad</string>
     <string name="room_member_power_level_admin_in">Peakasutaja jututoas %1$s</string>
     <string name="room_member_power_level_moderator_in">Moderaator jututoas %1$s</string>
     <string name="room_member_power_level_default_in">Vaikimisi õigused jututoas %1$s</string>
-    <string name="room_member_power_level_custom_in">Kohandatud õigused (%1$d) jututoas %2$s</string>
     <string name="room_member_jump_to_read_receipt">Hüppa lugemisteatise juurde</string>
     <string name="rendering_event_error_type_of_event_not_handled">${app_name} ei oska käsitleda %1$s-tüüpi sündmusi</string>
     <string name="rendering_event_error_exception">Tekkis viga, kui ${app_name} üritas töödelda sõnumi %1$s sisu</string>

--- a/library/ui-strings/src/main/res/values-eu/strings.xml
+++ b/library/ui-strings/src/main/res/values-eu/strings.xml
@@ -1106,12 +1106,10 @@ Errore hau ${app_name}-en kontroletik kanpo dago. Ez dago Google konturik gailua
     <string name="room_profile_leaving_room">Gelatik ateratzen…</string>
     <string name="room_member_power_level_admins">Administratzaileak</string>
     <string name="room_member_power_level_moderators">Moderatzaileak</string>
-    <string name="room_member_power_level_custom">Pertsonalizatua</string>
     <string name="room_member_power_level_invites">Gonbidapenak</string>
     <string name="room_member_power_level_users">Erabiltzaileak</string>
     <string name="room_member_power_level_admin_in">%1$s gelako administratzailea</string>
     <string name="room_member_power_level_moderator_in">%1$s gelako moderatzailea</string>
-    <string name="room_member_power_level_custom_in">Pertsonalizatua (%1$d) %2$s gelan</string>
     <string name="room_member_jump_to_read_receipt">Saltatu irakurragirira</string>
     <string name="rendering_event_error_type_of_event_not_handled">${app_name} aplikazioak ez ditu \'%1$s\' motako gertaerak kudeatzen</string>
     <string name="rendering_event_error_exception">${app_name} aplikazioak arazo bat izan du \'%1$s\' id-a duen edukia erakusteko</string>

--- a/library/ui-strings/src/main/res/values-fa/strings.xml
+++ b/library/ui-strings/src/main/res/values-fa/strings.xml
@@ -126,8 +126,6 @@
     <string name="power_level_admin">مدیر</string>
     <string name="power_level_moderator">ناظم</string>
     <string name="power_level_default">پیش‌گزیده</string>
-    <string name="power_level_custom">سفارشی (%1$d)</string>
-    <string name="power_level_custom_no_value">سفارشی</string>
     <string name="notice_power_level_changed_by_you">سطح قدرت %1$s را تغییر دادید.</string>
     <string name="notice_power_level_changed">%1$s سطح قدرت %2$s را تغییر داد.</string>
     <string name="notice_power_level_diff">%1$s از %2$s به %3$s</string>
@@ -956,13 +954,11 @@
     <string name="room_profile_leaving_room">ترک کردن اتاق…</string>
     <string name="room_member_power_level_admins">مدیران</string>
     <string name="room_member_power_level_moderators">ناظم‌ها</string>
-    <string name="room_member_power_level_custom">سفارشی</string>
     <string name="room_member_power_level_invites">دعوت‌ها</string>
     <string name="room_member_power_level_users">کاربران</string>
     <string name="room_member_power_level_admin_in">مدیر در %1$s</string>
     <string name="room_member_power_level_moderator_in">ناظم در %1$s</string>
     <string name="room_member_power_level_default_in">پیش گزیده در %1$s</string>
-    <string name="room_member_power_level_custom_in">سفارشی (%1$d) در %2$s</string>
     <string name="room_member_jump_to_read_receipt">پرش به رسیدِ خواندن</string>
     <string name="unignore">لغو نادیده‌گرفتن</string>
     <string name="room_settings_enable_encryption_dialog_submit">به کار انداختن رمزنگاری</string>

--- a/library/ui-strings/src/main/res/values-fi/strings.xml
+++ b/library/ui-strings/src/main/res/values-fi/strings.xml
@@ -99,8 +99,6 @@
     <string name="room_displayname_empty_room_was">Tyhjä huone (oli %s)</string>
     <string name="room_displayname_4_members">%1$s, %2$s, %3$s ja %4$s</string>
     <string name="room_displayname_3_members">%1$s, %2$s ja %3$s</string>
-    <string name="power_level_custom_no_value">Mukautettu</string>
-    <string name="power_level_custom">Mukautettu (%1$d)</string>
     <string name="power_level_default">Oletus</string>
     <string name="power_level_moderator">Valvoja</string>
     <string name="power_level_admin">Ylläpitäjä</string>
@@ -1285,8 +1283,6 @@
     <string name="bootstrap_crosssigning_print_it">Tulosta se jos mahdollista ja säilytä tuloste turvallisessa paikassa</string>
     <string name="bootstrap_crosssigning_save_usb">Tallenna se muistitikulle tai varmuuskopiolevylle talteen</string>
     <string name="bootstrap_crosssigning_save_cloud">Kopioi se henkilökohtaiseen pilvitallennustilaasi</string>
-    <string name="room_member_power_level_custom">Mukautettu</string>
-    <string name="room_member_power_level_custom_in">Mukautettu (%1$d) %2$s:ssä</string>
     <string name="delete_event_dialog_reason_hint">Syy poistoon</string>
     <string name="message_key">Viestin avain</string>
     <string name="audio_video_meeting_description">Tapaamiset käyttävät Jitsin turvallisuus- ja käyttöoikeuskäytäntöjä. Kaikki huoneessa olevat henkilöt näkevät kutsun tapaamiseen liittymiseksi niin kauan kuin tapaaminen on käynnissä.</string>

--- a/library/ui-strings/src/main/res/values-fr-rCA/strings.xml
+++ b/library/ui-strings/src/main/res/values-fr-rCA/strings.xml
@@ -123,13 +123,11 @@
     <string name="rendering_event_error_type_of_event_not_handled">${app_name} ne gère pas les évènements de type « %1$s »</string>
     <string name="room_member_jump_to_read_receipt">Aller à l’accusé de lecture</string>
     <string name="room_member_open_or_create_dm">Conversation privée</string>
-    <string name="room_member_power_level_custom_in">Personnalisé (%1$d) dans %2$s</string>
     <string name="room_member_power_level_default_in">Par défaut dans %1$s</string>
     <string name="room_member_power_level_moderator_in">Modérateur dans %1$s</string>
     <string name="room_member_power_level_admin_in">Administrateur dans %1$s</string>
     <string name="room_member_power_level_users">Utilisateurs</string>
     <string name="room_member_power_level_invites">Invitations</string>
-    <string name="room_member_power_level_custom">Personnalisé</string>
     <string name="room_member_power_level_moderators">Modérateurs</string>
     <string name="room_member_power_level_admins">Administrateurs</string>
     <string name="room_profile_leaving_room">En train de quitter le salon…</string>
@@ -1771,8 +1769,6 @@
     <string name="notice_power_level_diff">%1$s de %2$s à %3$s</string>
     <string name="notice_power_level_changed">%1$s a modifié le rang de %2$s.</string>
     <string name="notice_power_level_changed_by_you">Vous avez modifié le rang de %1$s.</string>
-    <string name="power_level_custom_no_value">Personnalisé</string>
-    <string name="power_level_custom">Personnalisé (%1$d)</string>
     <string name="power_level_default">Défaut</string>
     <string name="power_level_moderator">Modérateur</string>
     <string name="power_level_admin">Admin</string>

--- a/library/ui-strings/src/main/res/values-fr/strings.xml
+++ b/library/ui-strings/src/main/res/values-fr/strings.xml
@@ -133,8 +133,6 @@
     <string name="notice_power_level_diff">%1$s de %2$s à %3$s</string>
     <string name="notice_power_level_changed">%1$s a modifié le rang de %2$s.</string>
     <string name="notice_power_level_changed_by_you">Vous avez modifié le rang de %1$s.</string>
-    <string name="power_level_custom_no_value">Personnalisé</string>
-    <string name="power_level_custom">Personnalisé (%1$d)</string>
     <string name="power_level_default">Défaut</string>
     <string name="power_level_moderator">Modérateur</string>
     <string name="power_level_admin">Admin</string>
@@ -1222,12 +1220,10 @@
     <string name="room_profile_leaving_room">En train de quitter le salon…</string>
     <string name="room_member_power_level_admins">Administrateurs</string>
     <string name="room_member_power_level_moderators">Modérateurs</string>
-    <string name="room_member_power_level_custom">Personnalisé</string>
     <string name="room_member_power_level_invites">Invitations</string>
     <string name="room_member_power_level_users">Utilisateurs</string>
     <string name="room_member_power_level_admin_in">Administrateur dans %1$s</string>
     <string name="room_member_power_level_moderator_in">Modérateur dans %1$s</string>
-    <string name="room_member_power_level_custom_in">Personnalisé (%1$d) dans %2$s</string>
     <string name="room_member_jump_to_read_receipt">Aller à l’accusé de lecture</string>
     <string name="rendering_event_error_type_of_event_not_handled">${app_name} ne gère pas les évènements de type « %1$s »</string>
     <string name="rendering_event_error_exception">${app_name} a rencontré un problème lors de l’affichage du contenu de l’évènement ayant pour identifiant « %1$s »</string>

--- a/library/ui-strings/src/main/res/values-fy/strings.xml
+++ b/library/ui-strings/src/main/res/values-fy/strings.xml
@@ -122,8 +122,6 @@
     <string name="medium_email">E-mailadres</string>
     <string name="medium_phone_number">Telefoannûmer</string>
     <string name="notice_crypto_unable_to_decrypt">** Koe net ûntsiferje: %s **</string>
-    <string name="power_level_custom_no_value">Oanpast</string>
-    <string name="power_level_custom">Oanpast (%1$d)</string>
     <string name="power_level_default">Standert</string>
     <string name="power_level_admin">Behearder</string>
     <string name="notice_room_server_acl_updated_no_change">Gjin wizigingen.</string>

--- a/library/ui-strings/src/main/res/values-ga/strings.xml
+++ b/library/ui-strings/src/main/res/values-ga/strings.xml
@@ -85,7 +85,6 @@
     <string name="ok">Ceart go leor</string>
     <string name="loading">Ag lódáil…</string>
     <string name="title_activity_settings">Socruithe</string>
-    <string name="power_level_custom_no_value">Saincheaptha</string>
     <string name="power_level_default">Réamhshocrú</string>
     <string name="power_level_moderator">Modhnóir</string>
     <string name="power_level_admin">Riarthóir</string>

--- a/library/ui-strings/src/main/res/values-gl/strings.xml
+++ b/library/ui-strings/src/main/res/values-gl/strings.xml
@@ -134,8 +134,6 @@
     <string name="notice_power_level_diff">%1$s de %2$s a %3$s</string>
     <string name="notice_power_level_changed">%1$s cambiou de categoría a %2$s.</string>
     <string name="notice_power_level_changed_by_you">Cambiaches a categoría de %1$s.</string>
-    <string name="power_level_custom_no_value">Personalizado</string>
-    <string name="power_level_custom">Personalizado (%1$d)</string>
     <string name="power_level_default">Por defecto</string>
     <string name="power_level_moderator">Moderadora</string>
     <string name="power_level_admin">Admin</string>

--- a/library/ui-strings/src/main/res/values-hr/strings.xml
+++ b/library/ui-strings/src/main/res/values-hr/strings.xml
@@ -759,12 +759,10 @@
     <string name="room_profile_leaving_room">Napuštanje sobe…</string>
     <string name="room_member_power_level_admins">Administratori</string>
     <string name="room_member_power_level_moderators">Moderatori</string>
-    <string name="room_member_power_level_custom">Prilagođeno</string>
     <string name="room_member_power_level_invites">Pozivnice</string>
     <string name="room_member_power_level_users">Korisnici</string>
     <string name="room_member_power_level_admin_in">Administrator u %1$s</string>
     <string name="room_member_power_level_moderator_in">Moderator u %1$s</string>
-    <string name="room_member_power_level_custom_in">Prilagođeno (%1$d) u %2$s</string>
     <string name="room_member_jump_to_read_receipt">Skoči na potvrdu o pročitanoj poruci</string>
     <string name="rendering_event_error_type_of_event_not_handled">${app_name} ne podržava događaje tipa \'%1$s\'</string>
     <string name="rendering_event_error_exception">${app_name} je naišao na problem pri prikazu sadržaja događaja s identitetom \'%1$s\'</string>

--- a/library/ui-strings/src/main/res/values-hu/strings.xml
+++ b/library/ui-strings/src/main/res/values-hu/strings.xml
@@ -109,8 +109,6 @@
     <string name="notice_direct_room_created_by_you">Elkészítette a beszélgetést</string>
     <string name="notice_direct_room_created">%1$s elkészítette a beszélgetést</string>
     <string name="notice_room_created_by_you">Elkészítette a szobát</string>
-    <string name="power_level_custom_no_value">Egyéni</string>
-    <string name="power_level_custom">Egyéni (%1$d)</string>
     <string name="power_level_default">Alapértelmezett</string>
     <string name="power_level_moderator">Moderátor</string>
     <string name="power_level_admin">Admin</string>
@@ -1179,12 +1177,10 @@ A Visszaállítási Kulcsot tartsd biztonságos helyen, mint pl. egy jelszókeze
     <string name="room_profile_leaving_room">Kilépés a szobából…</string>
     <string name="room_member_power_level_admins">Adminok</string>
     <string name="room_member_power_level_moderators">Moderátorok</string>
-    <string name="room_member_power_level_custom">Egyedi</string>
     <string name="room_member_power_level_invites">Meghívók</string>
     <string name="room_member_power_level_users">Felhasználók</string>
     <string name="room_member_power_level_admin_in">Adminisztrátor itt: %1$s</string>
     <string name="room_member_power_level_moderator_in">Moderátor itt: %1$s</string>
-    <string name="room_member_power_level_custom_in">Egyedi (%1$d) itt: %2$s</string>
     <string name="room_member_jump_to_read_receipt">Olvasási visszaigazolásra ugrás</string>
     <string name="rendering_event_error_type_of_event_not_handled">${app_name} nem kezeli ezt az eseményt: \'%1$s\'</string>
     <string name="rendering_event_error_exception">${app_name} problémába ütközött az esemény (azon: %1$s) megjelenítésekor</string>

--- a/library/ui-strings/src/main/res/values-in/strings.xml
+++ b/library/ui-strings/src/main/res/values-in/strings.xml
@@ -785,8 +785,6 @@ Di masa mendatang proses verifikasi ini akan dimutakhirkan.</string>
     <string name="notice_crypto_unable_to_decrypt">** Tidak dapat mendekripsi: %s **</string>
     <string name="notice_power_level_diff">%1$s dari %2$s ke %3$s</string>
     <string name="notice_power_level_changed_by_you">Anda mengubah tingkat daya %1$s.</string>
-    <string name="power_level_custom_no_value">Kustom</string>
-    <string name="power_level_custom">Kustom (%1$d)</string>
     <string name="power_level_default">Standar</string>
     <string name="power_level_moderator">Moderator</string>
     <string name="power_level_admin">Admin</string>
@@ -1468,12 +1466,10 @@ Di masa mendatang proses verifikasi ini akan dimutakhirkan.</string>
     <string name="rendering_event_error_type_of_event_not_handled">${app_name} tidak mendukung peristiwa dengan tipe \'%1$s\'</string>
     <string name="room_member_open_or_create_dm">Pesan langsung</string>
     <string name="room_member_power_level_default_in">Standar di %1$s</string>
-    <string name="room_member_power_level_custom_in">Kustom (%1$d) di %2$s</string>
     <string name="room_member_power_level_admin_in">Admin di %1$s</string>
     <string name="room_member_power_level_moderator_in">Moderator di %1$s</string>
     <string name="room_member_power_level_users">Pengguna</string>
     <string name="room_member_power_level_invites">Undangan</string>
-    <string name="room_member_power_level_custom">Kustom</string>
     <string name="room_member_power_level_moderators">Moderator</string>
     <string name="room_member_power_level_admins">Admin</string>
     <string name="room_profile_leaving_room">Meninggalkan ruangan…</string>

--- a/library/ui-strings/src/main/res/values-is/strings.xml
+++ b/library/ui-strings/src/main/res/values-is/strings.xml
@@ -629,7 +629,6 @@
     <string name="new_session">Ný innskráning. Varst þetta þú\?</string>
     <string name="no_connectivity_to_the_server_indicator_airplane">Flugvélahamur er virkur</string>
     <string name="not_trusted">Ekki treyst</string>
-    <string name="room_member_power_level_custom_in">Sérsniðið (%1$d) í %2$s</string>
     <string name="room_member_power_level_default_in">Sjálfgefið í %1$s</string>
     <string name="room_member_power_level_moderator_in">Umsjónarmaður í %1$s</string>
     <string name="room_member_power_level_admin_in">Stjórnandi í %1$s</string>
@@ -1139,7 +1138,6 @@
     <string name="unignore">Hætta að hunsa</string>
     <string name="room_member_power_level_users">Notendur</string>
     <string name="room_member_power_level_invites">Boðsgestir</string>
-    <string name="room_member_power_level_custom">Sérsniðið</string>
     <string name="room_member_power_level_moderators">Umsjónarmenn</string>
     <string name="direct_room_profile_section_more_leave">Fara út</string>
     <string name="room_profile_section_more_leave">Fara af spjallrás</string>
@@ -1518,8 +1516,6 @@
         <item quantity="other">%1$s, %2$s, %3$s og %4$d til viðbótar</item>
     </plurals>
     <string name="room_displayname_3_members">%1$s, %2$s og %3$s</string>
-    <string name="power_level_custom_no_value">Sérsniðið</string>
-    <string name="power_level_custom">Sérsniðið (%1$d)</string>
     <string name="power_level_default">Sjálfgefið</string>
     <string name="power_level_moderator">Umsjónarmaður</string>
     <string name="notice_direct_room_third_party_invite">%1$s bauð %2$s</string>

--- a/library/ui-strings/src/main/res/values-it/strings.xml
+++ b/library/ui-strings/src/main/res/values-it/strings.xml
@@ -126,8 +126,6 @@
     <string name="power_level_admin">Amministratore</string>
     <string name="power_level_moderator">Moderatore</string>
     <string name="power_level_default">Standard</string>
-    <string name="power_level_custom">Personalizzato (%1$d)</string>
-    <string name="power_level_custom_no_value">Personalizzato</string>
     <string name="notice_power_level_changed_by_you">Hai cambiato le autorizzazioni di %1$s.</string>
     <string name="notice_power_level_changed">%1$s ha cambiato le autorizzazioni di %2$s.</string>
     <string name="notice_power_level_diff">%1$s da %2$s a %3$s</string>
@@ -1238,12 +1236,10 @@
     <string name="room_profile_leaving_room">Uscita dalla stanza…</string>
     <string name="room_member_power_level_admins">Amministratori</string>
     <string name="room_member_power_level_moderators">Moderatori</string>
-    <string name="room_member_power_level_custom">Personalizzato</string>
     <string name="room_member_power_level_invites">Inviti</string>
     <string name="room_member_power_level_users">Utenti</string>
     <string name="room_member_power_level_admin_in">Amministratore in %1$s</string>
     <string name="room_member_power_level_moderator_in">Moderatore in %1$s</string>
-    <string name="room_member_power_level_custom_in">Personalizzato (%1$d) in %2$s</string>
     <string name="room_member_jump_to_read_receipt">Vai alla ricevuta di lettura</string>
     <string name="rendering_event_error_type_of_event_not_handled">${app_name} non gestisce eventi del tipo \'%1$s\'</string>
     <string name="rendering_event_error_exception">${app_name} ha riscontrato un errore con il rendering del contenuto dell\'evento con id \'%1$s\'</string>

--- a/library/ui-strings/src/main/res/values-iw/strings.xml
+++ b/library/ui-strings/src/main/res/values-iw/strings.xml
@@ -1250,13 +1250,11 @@
     <string name="system_theme">ברירת מחדל מערכת</string>
     <string name="room_member_jump_to_read_receipt">קפצו לקבלת קריאה</string>
     <string name="room_member_open_or_create_dm">הודעה ישירה</string>
-    <string name="room_member_power_level_custom_in">מותאם אישית (%1$d) ב-%2$s</string>
     <string name="room_member_power_level_default_in">ברירת מחדל ב-%1$s</string>
     <string name="room_member_power_level_moderator_in">מנחה ב-%1$s</string>
     <string name="room_member_power_level_admin_in">מנהל מערכת ב-%1$s</string>
     <string name="room_member_power_level_users">משתמשים</string>
     <string name="room_member_power_level_invites">הזמנות</string>
-    <string name="room_member_power_level_custom">מותאם אישית</string>
     <string name="room_member_power_level_moderators">מנחים</string>
     <plurals name="room_profile_section_more_member_list">
         <item quantity="one">אדם אחד</item>
@@ -1801,8 +1799,6 @@
     <string name="notice_power_level_diff">%1$s מ-%2$s עד %3$s</string>
     <string name="notice_power_level_changed">%1$s שינה את רמת העוצמה של %2$s.</string>
     <string name="notice_power_level_changed_by_you">שינית את רמת העוצמה של %1$s.</string>
-    <string name="power_level_custom_no_value">מותאם אישית</string>
-    <string name="power_level_custom">מותאם אישית (%1$d)</string>
     <string name="power_level_default">ברירת מחדל</string>
     <string name="power_level_moderator">מַנחֶה</string>
     <string name="power_level_admin">מנהל מערכת</string>

--- a/library/ui-strings/src/main/res/values-ja/strings.xml
+++ b/library/ui-strings/src/main/res/values-ja/strings.xml
@@ -537,13 +537,11 @@
     <string name="room_profile_leaving_room">ルームから退出しています…</string>
     <string name="room_member_power_level_admins">管理者</string>
     <string name="room_member_power_level_moderators">モデレーター</string>
-    <string name="room_member_power_level_custom">ユーザー定義</string>
     <string name="room_member_power_level_invites">招待中</string>
     <string name="room_member_power_level_users">ユーザー</string>
     <string name="room_member_power_level_admin_in">%1$sの管理者</string>
     <string name="room_member_power_level_moderator_in">%1$sのモデレーター</string>
     <string name="room_member_power_level_default_in">%1$sの既定のユーザー</string>
-    <string name="room_member_power_level_custom_in">%2$sのユーザー定義（%1$d）</string>
     <string name="settings_category_timeline">タイムライン</string>
     <string name="room_settings_enable_encryption">エンドツーエンド暗号化を有効にする…</string>
     <string name="room_settings_enable_encryption_dialog_submit">暗号化を有効にする</string>
@@ -911,8 +909,6 @@
     <string name="room_displayname_4_members">%1$s、%2$s、%3$sと%4$s</string>
     <string name="room_displayname_3_members">%1$s、%2$sと%3$s</string>
     <string name="notice_power_level_diff">%1$sの権限レベルを%2$sから%3$sへ</string>
-    <string name="power_level_custom_no_value">ユーザー定義</string>
-    <string name="power_level_custom">ユーザー定義 (%1$d)</string>
     <string name="power_level_default">既定</string>
     <string name="power_level_moderator">モデレーター</string>
     <string name="power_level_admin">管理者</string>

--- a/library/ui-strings/src/main/res/values-ka/strings.xml
+++ b/library/ui-strings/src/main/res/values-ka/strings.xml
@@ -69,7 +69,6 @@
     <string name="power_level_admin">ადმინისტრატორი</string>
     <string name="power_level_moderator">მოდერატორი</string>
     <string name="power_level_default">ნაგულისხმევი</string>
-    <string name="power_level_custom">მორგებული (%1$d)</string>
     <string name="notice_power_level_changed">%1$s შეცვალა %2$s-ის ძალაუფლების დონე.</string>
     <string name="notice_power_level_diff">%1$s %2$s-დან %3$s-მდე</string>
     <string name="notice_crypto_unable_to_decrypt">** ვერ ხერხდება დეშიფრაცია: %s **</string>
@@ -148,7 +147,6 @@
     <string name="notice_room_leave_by_you">თქვენ დატოვეთ ოთახი</string>
     <string name="notice_widget_modified_by_you">თქვენ შეცვალეთ %1$s ვიჯეტი</string>
     <string name="notice_direct_room_leave">%1$s დატოვა ოთახი</string>
-    <string name="power_level_custom_no_value">მორგებული</string>
     <string name="notice_room_remove">%1$s ამოიღო %2$s</string>
     <string name="notice_power_level_changed_by_you">თქვენ შეცვალეთ %1$s-ის ძალაუფლების დონე.</string>
     <string name="notice_room_unban_by_you">თქვენ მოხსენით აკრძალვა %1$s-ზე</string>
@@ -1574,7 +1572,6 @@
     <string name="room_member_power_level_users">მომხმარებლები</string>
     <string name="room_member_power_level_admin_in">ადმინი %1$s-ში</string>
     <string name="room_member_power_level_default_in">ნაგულისხმები %1$s-ში</string>
-    <string name="room_member_power_level_custom_in">მორგებული (%1$d) %2$s-ში</string>
     <string name="room_member_open_or_create_dm">პირდაპირი შეტყობინება</string>
     <string name="unignore">უარყოფა</string>
     <string name="command_description_rainbow">გზავნის მოცემულ შეტყობინებას ცისარტყელას ფერებში</string>
@@ -2123,7 +2120,6 @@
     <string name="direct_room_profile_section_more_settings">პარამეტრები</string>
     <string name="room_profile_section_more_uploads">ატვირთვები</string>
     <string name="room_profile_leaving_room">ოთახის დატოვება…</string>
-    <string name="room_member_power_level_custom">მორგებული</string>
     <string name="room_member_power_level_moderator_in">მოდერატორი %1$s-ში</string>
     <string name="room_member_jump_to_read_receipt">გადასვლა წაკითხულ მისამართზე</string>
     <string name="rendering_event_error_type_of_event_not_handled">${app_name} ვერ ამუშავებს ტიპის \'%1$s\' მოვლენებს</string>

--- a/library/ui-strings/src/main/res/values-kab/strings.xml
+++ b/library/ui-strings/src/main/res/values-kab/strings.xml
@@ -19,7 +19,6 @@
     <string name="power_level_admin">Anedbal</string>
     <string name="power_level_moderator">Aseɣyad</string>
     <string name="power_level_default">Amezwer</string>
-    <string name="power_level_custom_no_value">Sagen</string>
     <string name="notice_power_level_diff">%1$s seg %2$s ɣer %3$s</string>
     <string name="medium_email">Tansa n yimayl</string>
     <string name="notice_room_unban">%1$s yekkes agdal i %2$s</string>
@@ -74,7 +73,6 @@
     <string name="notice_widget_removed_by_you">Tekkseḍ awiǧit %1$s</string>
     <string name="notice_widget_modified">%1$s ibeddel awiǧit %2$s</string>
     <string name="notice_widget_modified_by_you">Tbeddleḍ awiǧit %1$s</string>
-    <string name="power_level_custom">Sagen (%1$d)</string>
     <string name="notice_power_level_changed_by_you">Tbeddleḍ aswir n tezmert n %1$s.</string>
     <string name="notice_power_level_changed">%1$s ibeddel aswir n tezmert n %2$s.</string>
     <string name="notice_crypto_unable_to_decrypt">** Awgelhen d awezɣi: %s **</string>
@@ -431,7 +429,6 @@
     <string name="room_profile_section_more_notifications">Ilɣa</string>
     <string name="room_profile_section_more_leave">Ffeɣ seg texxamt</string>
     <string name="room_member_power_level_admins">Inedbalen</string>
-    <string name="room_member_power_level_custom">Sagen</string>
     <string name="room_member_power_level_invites">Inced-d</string>
     <string name="room_member_power_level_users">Iseqdacen</string>
     <string name="room_member_jump_to_read_receipt">Ɛeddi ɣer tɣuri n wawwaḍ</string>
@@ -1446,7 +1443,6 @@
     <string name="room_member_power_level_admin_in">Anedbal deg %1$s</string>
     <string name="room_member_power_level_moderator_in">D amaẓrag deg %1$s</string>
     <string name="room_member_power_level_default_in">Amezwer deg %1$s</string>
-    <string name="room_member_power_level_custom_in">D udmawan (%1$d) deg %2$s</string>
     <string name="rendering_event_error_type_of_event_not_handled">"${app_name} ur isekker ara ineḍruyen n wanaw  \'%1$s\'"</string>
     <string name="rendering_event_error_exception">${app_name} yemlal-d ugur mi ara d-yettarra agbur n uneḍru s usulay \'%1$s\'</string>
     <string name="verify_cannot_cross_sign">Tiɣimit-a ulamek ara tebḍu aselken-a akked tqimiyin-nniḍen.

--- a/library/ui-strings/src/main/res/values-lo/strings.xml
+++ b/library/ui-strings/src/main/res/values-lo/strings.xml
@@ -549,8 +549,6 @@
     <string name="notice_power_level_diff">%1$s ຈາກ %2$s ຫາ %3$s</string>
     <string name="notice_power_level_changed">%1$s ໄດ້ປ່ຽນລະດັບພະລັງງານຂອງ %2$s.</string>
     <string name="notice_power_level_changed_by_you">ທ່ານໄດ້ປ່ຽນລະດັບພະລັງງານຂອງ %1$s.</string>
-    <string name="power_level_custom_no_value">ກຳນົດເອງ</string>
-    <string name="power_level_custom">ກຳນົດເອງ (%1$d)</string>
     <string name="power_level_admin">ຜູ້ເບີ່ງເເຍງລະບົບ</string>
     <string name="power_level_default">ຄ່າເລີ່ມຕົ້ນ</string>
     <string name="power_level_moderator">ຜູ້ຄວບຄຸມ</string>
@@ -2222,13 +2220,11 @@
     <string name="rendering_event_error_type_of_event_not_handled">${app_name} ບໍ່ໄດ້ຈັດການ ເຫດການຂອງປະເພດ \'%1$s\'</string>
     <string name="room_member_jump_to_read_receipt">ໄປເພື່ອອ່ານ</string>
     <string name="room_member_open_or_create_dm">ຂໍ້ຄວາມໂດຍກົງ</string>
-    <string name="room_member_power_level_custom_in">ກຳນົດເອງ (%1$d) ໃນ %2$s</string>
     <string name="room_member_power_level_default_in">ຄ່າເລີ່ມຕົ້ນໃນ %1$s</string>
     <string name="room_member_power_level_moderator_in">ຜູ້ຄວບຄຸມໃນ %1$s</string>
     <string name="room_member_power_level_admin_in">ຜູ້ເບິ່ງແຍງລະບົບໃນ %1$s</string>
     <string name="room_member_power_level_users">ຜູ້ໃຊ້</string>
     <string name="room_member_power_level_invites">ເຊີນ</string>
-    <string name="room_member_power_level_custom">ກຳນົດເອງ</string>
     <string name="room_member_power_level_moderators">ຜູ້ຄວບຄຸມ</string>
     <string name="room_member_power_level_admins">ຜູ້ເບິ່ງແຍງລະບົບ</string>
     <string name="room_member_override_nick_color">ໂຊທັບສີຂອງຊື່ນີ້</string>

--- a/library/ui-strings/src/main/res/values-lt/strings.xml
+++ b/library/ui-strings/src/main/res/values-lt/strings.xml
@@ -656,8 +656,6 @@
     <string name="notice_power_level_diff">%1$s nuo %2$s iki %3$s</string>
     <string name="notice_power_level_changed">%1$s pakeitė %2$s galios lygį.</string>
     <string name="notice_power_level_changed_by_you">Pakeitėte %1$s galios lygį.</string>
-    <string name="power_level_custom_no_value">Pasirinktinis</string>
-    <string name="power_level_custom">Pasirinktinis (%1$d)</string>
     <string name="power_level_default">Standartinis</string>
     <string name="power_level_moderator">Moderatorius</string>
     <string name="power_level_admin">Adminas</string>

--- a/library/ui-strings/src/main/res/values-lv/strings.xml
+++ b/library/ui-strings/src/main/res/values-lv/strings.xml
@@ -175,8 +175,6 @@
     <string name="notice_power_level_diff">%1$s no %2$s uz %3$s</string>
     <string name="notice_power_level_changed">%1$s nomainīja %2$s pieejas līmeni.</string>
     <string name="notice_power_level_changed_by_you">Tu nomainīji %1$s pieejas līmeni.</string>
-    <string name="power_level_custom_no_value">Pielāgots</string>
-    <string name="power_level_custom">Pielāgots (%1$d)</string>
     <string name="power_level_default">Noklusējuma</string>
     <string name="power_level_moderator">Moderators</string>
     <string name="power_level_admin">Administrators</string>
@@ -783,11 +781,9 @@ Nākotnē šī pārbaudes procedūra plānota sarežģītāka.</string>
     <string name="action_download">Lejupielādēt</string>
     <string name="are_you_sure">Vai tiešām to vēlaties\?</string>
     <string name="system_theme">Sistēmas noklusējuma</string>
-    <string name="room_member_power_level_custom_in">Pielāgots (%1$d) iekš %2$s</string>
     <string name="room_member_power_level_default_in">%1$s noklusējums</string>
     <string name="room_member_power_level_moderator_in">%1$s moderators</string>
     <string name="room_member_power_level_admin_in">%1$s administrators</string>
-    <string name="room_member_power_level_custom">Pielāgots</string>
     <string name="room_member_power_level_moderators">Moderators</string>
     <string name="room_member_power_level_admins">Administrators</string>
     <string name="encryption_information_unknown_ip">nepazīstama ip</string>

--- a/library/ui-strings/src/main/res/values-ml/strings.xml
+++ b/library/ui-strings/src/main/res/values-ml/strings.xml
@@ -438,8 +438,6 @@
     <string name="notice_crypto_unable_to_decrypt">** ഡീക്രിപ്റ്റ് ചെയ്യാൻ കഴിഞ്ഞില്ല: %s **</string>
     <string name="notice_power_level_changed">%1$s %2$s ന്റെ അധികാര നില മാറ്റി.</string>
     <string name="notice_power_level_changed_by_you">നിങ്ങൾ %1$s ന്റെ അധികാര നില മാറ്റി.</string>
-    <string name="power_level_custom_no_value">ഇച്ഛാനുസൃതം</string>
-    <string name="power_level_custom">ഇച്ഛാനുസൃതം (%1$d)</string>
     <string name="power_level_default">തനത്</string>
     <string name="power_level_moderator">മോഡറേറ്റർ</string>
     <string name="power_level_admin">അഡ്മിൻ</string>
@@ -672,7 +670,6 @@
     <string name="room_member_profile_sessions_section_title">സെഷനുകൾ</string>
     <string name="verification_profile_verified">പരിശോധിച്ചുറപ്പിച്ചു</string>
     <string name="room_member_power_level_invites">ക്ഷണങ്ങൾ</string>
-    <string name="room_member_power_level_custom">ഇച്ഛാനുസൃതം</string>
     <string name="room_member_power_level_moderators">മോഡറേറ്റർമാർ</string>
     <string name="direct_room_profile_section_more_leave">വിടുക</string>
     <string name="room_profile_section_security">സുരക്ഷ</string>

--- a/library/ui-strings/src/main/res/values-nb-rNO/strings.xml
+++ b/library/ui-strings/src/main/res/values-nb-rNO/strings.xml
@@ -240,7 +240,6 @@
     <string name="room_profile_section_more_notifications">Varsler</string>
     <string name="room_profile_section_more_uploads">Opplastinger</string>
     <string name="room_member_power_level_moderators">Ordstyrere</string>
-    <string name="room_member_power_level_custom">Tilpasset</string>
     <string name="room_member_power_level_invites">Invitasjoner</string>
     <string name="room_member_power_level_users">Brukere</string>
     <string name="unignore">Opphev ignorering</string>
@@ -1146,8 +1145,6 @@
     <string name="unable_to_send_message">Kan ikke sende melding</string>
     <string name="notice_crypto_error_unknown_inbound_session_id">Avsenderens enhet har ikke sendt oss nøklene til denne meldingen.</string>
     <string name="notice_crypto_unable_to_decrypt">** Kan ikke dekryptere: %s **</string>
-    <string name="power_level_custom_no_value">Tilpasset</string>
-    <string name="power_level_custom">Tilpasset (%1$d)</string>
     <string name="power_level_default">Standard</string>
     <string name="power_level_admin">Administrator</string>
     <string name="notice_room_third_party_registered_invite_by_you">Du godtok invitasjonen til %1$s</string>

--- a/library/ui-strings/src/main/res/values-nl/strings.xml
+++ b/library/ui-strings/src/main/res/values-nl/strings.xml
@@ -836,8 +836,6 @@
     <string name="notice_power_level_diff">%1$s van %2$s naar %3$s</string>
     <string name="notice_power_level_changed">%1$s heeft het machtigingsniveau van %2$s aangepast.</string>
     <string name="notice_power_level_changed_by_you">Je hebt het machtigingsniveau van %1$s aangepast.</string>
-    <string name="power_level_custom_no_value">Speciaal</string>
-    <string name="power_level_custom">Speciaal (%1$d)</string>
     <string name="power_level_default">Standaardlid</string>
     <string name="power_level_admin">Beheerder</string>
     <string name="notice_widget_modified_by_you">Je hebt de widget %1$s aangepast</string>
@@ -1120,7 +1118,6 @@
     <string name="unignore">Negeren opheffen</string>
     <string name="room_member_power_level_users">Personen</string>
     <string name="room_member_power_level_invites">Genodigden</string>
-    <string name="room_member_power_level_custom">Aangepast</string>
     <string name="room_member_power_level_moderators">Moderatoren</string>
     <string name="room_member_power_level_admins">Administrators</string>
     <string name="room_profile_section_more_uploads">Uploads</string>
@@ -2036,7 +2033,6 @@
     <string name="rendering_event_error_type_of_event_not_handled">${app_name} verwerkt geen gebeurtenissen van het type \'%1$s\'</string>
     <string name="room_member_jump_to_read_receipt">Ga naar ontvangstbewijs lezen</string>
     <string name="room_member_open_or_create_dm">Direct bericht</string>
-    <string name="room_member_power_level_custom_in">Aangepast (%1$d) in %2$s</string>
     <string name="room_member_power_level_default_in">Standaard in %1$s</string>
     <string name="room_member_power_level_moderator_in">Moderator in %1$s</string>
     <string name="room_member_power_level_admin_in">Beheerder in %1$s</string>

--- a/library/ui-strings/src/main/res/values-nn/strings.xml
+++ b/library/ui-strings/src/main/res/values-nn/strings.xml
@@ -494,12 +494,10 @@ Meldingssynlegheit på Matrix liknar på epost. At vi gløymer meldingane dine t
     <string name="room_profile_section_more_leave">Forlat rom</string>
     <string name="room_member_power_level_admins">Administratorar</string>
     <string name="room_member_power_level_moderators">Moderatorar</string>
-    <string name="room_member_power_level_custom">Tilpassa</string>
     <string name="room_member_power_level_invites">Invitasjonar</string>
     <string name="room_member_power_level_users">Brukarar</string>
     <string name="room_member_power_level_admin_in">Administrator i %1$s</string>
     <string name="room_member_power_level_moderator_in">Moderator i %1$s</string>
-    <string name="room_member_power_level_custom_in">Tilpassa (%1$d) i %2$s</string>
     <string name="verify_cannot_cross_sign">Denne økta klarde ikkje å dele denne verifikasjonen med dine andre økter.
 \nVerifikasjonsdata er lagra lokalt, og vil bli delt i ein framtidig versjon av programmet.</string>
     <string name="settings_category_timeline">Historikk</string>

--- a/library/ui-strings/src/main/res/values-pl/strings.xml
+++ b/library/ui-strings/src/main/res/values-pl/strings.xml
@@ -1080,12 +1080,10 @@
     <string name="room_profile_leaving_room">Opuszczanie pokoju…</string>
     <string name="room_member_power_level_admins">Administratorzy</string>
     <string name="room_member_power_level_moderators">Moderatorzy</string>
-    <string name="room_member_power_level_custom">Niestandardowy</string>
     <string name="room_member_power_level_invites">Zaproszenia</string>
     <string name="room_member_power_level_users">Użytkownicy</string>
     <string name="room_member_power_level_admin_in">Administrator w %1$s</string>
     <string name="room_member_power_level_moderator_in">Moderator w %1$s</string>
-    <string name="room_member_power_level_custom_in">Niestandardowy (%1$d) w %2$s</string>
     <string name="room_member_jump_to_read_receipt">Przeskocz do znacznika odczytania</string>
     <string name="rendering_event_error_type_of_event_not_handled">${app_name} nie obsługuje wydarzeń typu \'%1$s\'</string>
     <string name="rendering_event_error_exception">${app_name} napotkał problem przy wyświetlaniu zawartości wydarzenia z ID \'%1$s\'</string>
@@ -2022,8 +2020,6 @@
         <item quantity="other">%1$s, %2$s, %3$s i %4$d innych</item>
     </plurals>
     <string name="room_displayname_4_members">%1$s, %2$s, %3$s i %4$s</string>
-    <string name="power_level_custom_no_value">Niestandardowe</string>
-    <string name="power_level_custom">Niestandardowe (%1$d)</string>
     <string name="power_level_default">Domyślne</string>
     <string name="power_level_moderator">Moderator</string>
     <string name="power_level_admin">Administrator</string>

--- a/library/ui-strings/src/main/res/values-pt-rBR/strings.xml
+++ b/library/ui-strings/src/main/res/values-pt-rBR/strings.xml
@@ -84,8 +84,6 @@
     <string name="power_level_admin">Admin</string>
     <string name="power_level_moderator">Moderador(a)</string>
     <string name="power_level_default">Default</string>
-    <string name="power_level_custom">Personalizado (%1$d)</string>
-    <string name="power_level_custom_no_value">Personalizado</string>
     <string name="notice_power_level_changed_by_you">Você mudou o nível de poder de %1$s.</string>
     <string name="notice_power_level_changed">%1$s mudou o nível de poder de %2$s.</string>
     <string name="notice_power_level_diff">%1$s de %2$s para %3$s</string>
@@ -1337,13 +1335,11 @@
     <string name="room_profile_leaving_room">Saindo da sala…</string>
     <string name="room_member_power_level_admins">Admins</string>
     <string name="room_member_power_level_moderators">Moderadoras(es)</string>
-    <string name="room_member_power_level_custom">Personalizado</string>
     <string name="room_member_power_level_invites">Convites</string>
     <string name="room_member_power_level_users">Usuárias(os)</string>
     <string name="room_member_power_level_admin_in">Admin em %1$s</string>
     <string name="room_member_power_level_moderator_in">Moderador(a) em %1$s</string>
     <string name="room_member_power_level_default_in">Default em %1$s</string>
-    <string name="room_member_power_level_custom_in">Personalizado (%1$d) em %2$s</string>
     <string name="room_member_jump_to_read_receipt">Pular para recibo de leitura</string>
     <string name="rendering_event_error_type_of_event_not_handled">${app_name} não lida com eventos de tipo \'%1$s\'</string>
     <string name="rendering_event_error_exception">${app_name} encontrou um problema ao render conteúdo de evento com id \'%1$s\'</string>

--- a/library/ui-strings/src/main/res/values-ro/strings.xml
+++ b/library/ui-strings/src/main/res/values-ro/strings.xml
@@ -244,8 +244,6 @@
     <string name="notice_room_server_acl_set_title">%s Setați listele ACL pentru acestă cameră.</string>
     <string name="notice_room_unban_by_you">Ai deblocat %1$s</string>
     <string name="notice_room_unban">%1$s deblocat %2$s</string>
-    <string name="power_level_custom_no_value">Personalizat</string>
-    <string name="power_level_custom">Personalizat (%1$d)</string>
     <string name="power_level_default">Implicit</string>
     <string name="power_level_moderator">Moderator</string>
     <string name="power_level_admin">Administrator</string>

--- a/library/ui-strings/src/main/res/values-ru/strings.xml
+++ b/library/ui-strings/src/main/res/values-ru/strings.xml
@@ -122,8 +122,6 @@
     <string name="power_level_admin">Администратор</string>
     <string name="power_level_moderator">Модератор</string>
     <string name="power_level_default">По умолчанию</string>
-    <string name="power_level_custom">Пользовательский (%1$d)</string>
-    <string name="power_level_custom_no_value">Пользовательский</string>
     <string name="notice_power_level_changed_by_you">Вы изменили уровни доступа %1$s.</string>
     <string name="notice_power_level_changed">%1$s изменил(а) уровни доступа %2$s.</string>
     <string name="notice_power_level_diff">%1$s с %2$s на %3$s</string>
@@ -1405,12 +1403,10 @@
 \nВаши сообщения защищены замками и только вы и получатель имеете уникальные ключи для их разблокировки.</string>
     <string name="room_profile_section_admin">Действия Администратора</string>
     <string name="room_profile_leaving_room">Покидаем комнату…</string>
-    <string name="room_member_power_level_custom">Пользовательский</string>
     <string name="room_member_power_level_invites">Приглашения</string>
     <string name="room_member_power_level_admin_in">Администратор в %1$s</string>
     <string name="room_member_power_level_moderator_in">Модератор в %1$s</string>
     <string name="room_member_power_level_default_in">По умолчанию в %1$s</string>
-    <string name="room_member_power_level_custom_in">Пользовательский (%1$d) в %2$s</string>
     <string name="room_member_jump_to_read_receipt">Перейти к последнему прочтённому им сообщению</string>
     <string name="rendering_event_error_type_of_event_not_handled">${app_name} не обрабатывает события типа \'%1$s\'</string>
     <string name="rendering_event_error_exception">${app_name} столкнулся с проблемой при отображении содержимого события с идентификатором \'%1$s\'</string>

--- a/library/ui-strings/src/main/res/values-sk/strings.xml
+++ b/library/ui-strings/src/main/res/values-sk/strings.xml
@@ -125,8 +125,6 @@
     <string name="power_level_admin">Správca</string>
     <string name="power_level_moderator">Moderátor</string>
     <string name="power_level_default">Predvolený</string>
-    <string name="power_level_custom">Vlastná úroveň (%1$d)</string>
-    <string name="power_level_custom_no_value">Vlastná úroveň</string>
     <string name="notice_power_level_changed_by_you">Zmenili ste úroveň oprávnenia používateľa %1$s.</string>
     <string name="notice_power_level_changed">%1$s zmenil úroveň oprávnenia používateľa %2$s.</string>
     <string name="notice_power_level_diff">%1$s z %2$s na %3$s</string>
@@ -1196,7 +1194,6 @@
     <string name="unignore">Prestať ignorovať</string>
     <string name="room_member_power_level_users">Používatelia</string>
     <string name="room_member_power_level_invites">Pozvánky</string>
-    <string name="room_member_power_level_custom">Vlastná úroveň</string>
     <string name="room_member_power_level_moderators">Moderátori</string>
     <string name="room_member_power_level_admins">Správcovia</string>
     <string name="room_profile_section_more_uploads">Nahrané súbory</string>
@@ -1633,7 +1630,6 @@
     <string name="error_network_timeout">Zdá sa, že serveru trvá príliš dlho, kým odpovie, čo môže byť spôsobené buď zlým pripojením, alebo chybou servera. Skúste to o chvíľu znova.</string>
     <string name="identity_server_consent_dialog_content_question">Súhlasíte so zaslaním týchto informácií\?</string>
     <string name="room_member_jump_to_read_receipt">Preskočiť na potvrdenie o prečítaní</string>
-    <string name="room_member_power_level_custom_in">Vlastné (%1$d) v %2$s</string>
     <string name="room_member_power_level_default_in">Predvolené v %1$s</string>
     <string name="verification_no_scan_emoji_title">Overiť porovnaním emotikonov</string>
     <string name="verification_scan_self_emoji_subtitle">Namiesto toho overte porovnaním emotikonov</string>

--- a/library/ui-strings/src/main/res/values-sq/strings.xml
+++ b/library/ui-strings/src/main/res/values-sq/strings.xml
@@ -126,8 +126,6 @@
     <string name="power_level_admin">Përgjegjës</string>
     <string name="power_level_moderator">Moderator</string>
     <string name="power_level_default">Parazgjedhje</string>
-    <string name="power_level_custom">Vetjake (%1$d)</string>
-    <string name="power_level_custom_no_value">Vetjake</string>
     <string name="notice_power_level_changed_by_you">Ndryshuat shkallën e pushtetit për %1$s.</string>
     <string name="notice_power_level_changed">%1$s ndryshoi shkallën e pushtetit për %2$s.</string>
     <string name="notice_power_level_diff">%1$s nga %2$s në %3$s</string>
@@ -1222,12 +1220,10 @@
     <string name="room_profile_leaving_room">Po iket nga dhoma…</string>
     <string name="room_member_power_level_admins">Administratorë</string>
     <string name="room_member_power_level_moderators">Moderatorë</string>
-    <string name="room_member_power_level_custom">Vetjake</string>
     <string name="room_member_power_level_invites">Ftesa</string>
     <string name="room_member_power_level_users">Përdorues</string>
     <string name="room_member_power_level_admin_in">Administrator te %1$s</string>
     <string name="room_member_power_level_moderator_in">Moderator te %1$s</string>
-    <string name="room_member_power_level_custom_in">Vetjake (%1$d) te %2$s</string>
     <string name="room_member_jump_to_read_receipt">Hidhuni te leximi i faturës</string>
     <string name="unignore">Shpërfille</string>
     <string name="command_description_rainbow">E dërgon mesazhin e dhënë të ngjyrosur si ylber</string>

--- a/library/ui-strings/src/main/res/values-sr/strings.xml
+++ b/library/ui-strings/src/main/res/values-sr/strings.xml
@@ -56,8 +56,6 @@
     <string name="unable_to_send_message">Не могу да пошаљем поруку</string>
     <string name="notice_crypto_error_unknown_inbound_session_id">Уређај пошиљаоца није нам послао кључеве за ову поруку.</string>
     <string name="notice_power_level_changed_by_you">Изменили сте ниво снаге корисника %1$s.</string>
-    <string name="power_level_custom_no_value">посебно</string>
-    <string name="power_level_custom">посебно (%1$d)</string>
     <string name="power_level_default">подразумевано</string>
     <string name="power_level_moderator">модератор</string>
     <string name="power_level_admin">админ</string>

--- a/library/ui-strings/src/main/res/values-sv/strings.xml
+++ b/library/ui-strings/src/main/res/values-sv/strings.xml
@@ -75,8 +75,6 @@
     <string name="power_level_admin">Admin</string>
     <string name="power_level_moderator">Moderator</string>
     <string name="power_level_default">Standard</string>
-    <string name="power_level_custom">Anpassad (%1$d)</string>
-    <string name="power_level_custom_no_value">Anpassad</string>
     <string name="notice_power_level_changed_by_you">Du ändrade behörighetsnivå för %1$s.</string>
     <string name="notice_power_level_changed">%1$s ändrade behörighetsnivå för %2$s.</string>
     <string name="notice_power_level_diff">%1$s från %2$s till %3$s</string>
@@ -1480,13 +1478,11 @@
     <string name="room_profile_section_security">Säkerhet</string>
     <string name="room_profile_section_admin">Adminhandlingar</string>
     <string name="room_profile_leaving_room">Lämnar rummet…</string>
-    <string name="room_member_power_level_custom">Anpassad</string>
     <string name="room_member_power_level_invites">Inbjudningar</string>
     <string name="room_member_power_level_users">Användare</string>
     <string name="room_member_power_level_admin_in">Administratör i %1$s</string>
     <string name="room_member_power_level_moderator_in">Moderator i %1$s</string>
     <string name="room_member_power_level_default_in">Standardbehörig i %1$s</string>
-    <string name="room_member_power_level_custom_in">Anpassad (%1$d) i %2$s</string>
     <string name="room_member_jump_to_read_receipt">Hoppa till läskvitto</string>
     <string name="rendering_event_error_type_of_event_not_handled">${app_name} hanterar inte händelser av typen \'%1$s\'</string>
     <string name="rendering_event_error_exception">${app_name} stötte på ett fel vid rendering av innehållet i händelsen med id \'%1$s\'</string>

--- a/library/ui-strings/src/main/res/values-sw/strings.xml
+++ b/library/ui-strings/src/main/res/values-sw/strings.xml
@@ -111,8 +111,6 @@
     <string name="notice_widget_removed_by_you">Umeondoa %1$s wijeti</string>
     <string name="notice_widget_modified">%1$s imebadilishwa%2$s wijeti</string>
     <string name="notice_widget_modified_by_you">Umerekebisha %1$s wijeti</string>
-    <string name="power_level_custom">Desturi (%1$d)</string>
-    <string name="power_level_custom_no_value">Desturi</string>
     <string name="notice_power_level_changed">%1$s ilibadilisha kiwango cha nguvu %2$s.</string>
     <string name="notice_power_level_diff">%1$s kutoka %2$s kwa %3$s</string>
     <string name="notice_crypto_unable_to_decrypt">** Imeshindwa kusimbua: %s **</string>

--- a/library/ui-strings/src/main/res/values-tr/strings.xml
+++ b/library/ui-strings/src/main/res/values-tr/strings.xml
@@ -1177,7 +1177,6 @@
     <string name="event_status_sending_message">Mesaj gönderiliyor…</string>
     <string name="room_displayname_empty_room">Boş oda</string>
     <string name="room_displayname_3_members">%1$s, %2$s ve %3$s</string>
-    <string name="power_level_custom_no_value">Özel</string>
     <string name="notice_widget_removed_by_you">%1$s widgetını kaldırdınız</string>
     <string name="notice_widget_added_by_you">%1$s widgetını eklediniz</string>
     <string name="room_displayname_room_invite">Oda daveti</string>
@@ -1388,7 +1387,6 @@
     <string name="notice_power_level_diff">%1$s, %2$s ile %3$s arasında</string>
     <string name="notice_power_level_changed">%1$s, %2$s\'nin güç seviyesini değiştirdi.</string>
     <string name="notice_power_level_changed_by_you">%1$s\'nin güç seviyesini değiştirdiniz.</string>
-    <string name="power_level_custom">Özel (%1$d)</string>
     <string name="power_level_moderator">Moderatör</string>
     <string name="power_level_admin">Admin</string>
     <string name="notice_widget_modified_by_you">%1$s widget\'ını değiştirdiniz</string>

--- a/library/ui-strings/src/main/res/values-tt/strings.xml
+++ b/library/ui-strings/src/main/res/values-tt/strings.xml
@@ -8,7 +8,6 @@
     </plurals>
     <string name="notice_room_server_acl_updated_no_change">Үзгәреш юк.</string>
     <string name="power_level_default">Килешенгәнчә</string>
-    <string name="power_level_custom_no_value">Шәхси</string>
     <string name="matrix_error">Matrix хатасы</string>
     <string name="room_displayname_two_members">%1$s һәм %2$s</string>
     <string name="room_displayname_3_members">%1$s, %2$s һәм %3$s</string>

--- a/library/ui-strings/src/main/res/values-uk/strings.xml
+++ b/library/ui-strings/src/main/res/values-uk/strings.xml
@@ -125,8 +125,6 @@
     <string name="initial_sync_start_importing_account">Початкова синхронізація:
 \nІмпортування даних облікового запису…</string>
     <string name="room_displayname_empty_room_was">Порожня кімната (була %s)</string>
-    <string name="power_level_custom_no_value">Не типовий</string>
-    <string name="power_level_custom">Не типовий (%1$d)</string>
     <string name="notice_widget_modified_by_you">Ви змінили віджет %1$s</string>
     <string name="notice_widget_modified">%1$s змінює віджет %2$s</string>
     <string name="notice_direct_room_update_by_you">Ви оновили кімнату.</string>
@@ -1376,8 +1374,6 @@
     <string name="room_settings_enable_encryption_dialog_title">Увімкнути шифрування\?</string>
     <string name="command_description_rainbow_emote">Надсилає емоджі розмальоване веселково</string>
     <string name="room_member_open_or_create_dm">Особисте повідомлення</string>
-    <string name="room_member_power_level_custom_in">Не типовий (%1$d) у %2$s</string>
-    <string name="room_member_power_level_custom">Не типовий</string>
     <string name="notice_power_level_diff">%1$s з %2$s до %3$s</string>
     <string name="notice_power_level_changed">%1$s змінює рівень повноважень %2$s.</string>
     <string name="room_profile_section_admin">Дії адміністратора</string>

--- a/library/ui-strings/src/main/res/values-ur/strings.xml
+++ b/library/ui-strings/src/main/res/values-ur/strings.xml
@@ -102,7 +102,6 @@
     <string name="power_level_moderator">ناظم</string>
     <string name="power_level_default">معین</string>
     <string name="notice_power_level_changed_by_you">آپنے درجۂ طاقت بدلے %1$s کے۔</string>
-    <string name="power_level_custom">حسب ضرورت (%1$d)</string>
     <string name="notice_power_level_changed">%1$s نے درجۂ طاقت بدلے %2$s کے۔</string>
     <string name="notice_power_level_diff">%1$s از %2$s تا %3$s</string>
     <string name="medium_phone_number">ہاتفی عدد</string>
@@ -147,7 +146,6 @@
     <string name="notice_widget_removed">%1$s نے %2$s وجیٹ ہٹا دیا</string>
     <string name="notice_widget_removed_by_you">آپنے %1$s وجیٹ ہٹا دیا</string>
     <string name="notice_widget_modified_by_you">آپنے %1$s وجیٹ ترمیم کیا</string>
-    <string name="power_level_custom_no_value">حسب ضرورت</string>
     <string name="notice_crypto_unable_to_decrypt">**ناقابل رمز کشائی: %s**</string>
     <string name="notice_crypto_error_unknown_inbound_session_id">ارسال کنندہ کے آلے نے ہمیں اس پیغام کیلئے چابیاں نہیں بھیجیں۔</string>
     <string name="unable_to_send_message">پیغام بھیجنے کے قابل نہیں</string>

--- a/library/ui-strings/src/main/res/values-vi/strings.xml
+++ b/library/ui-strings/src/main/res/values-vi/strings.xml
@@ -204,8 +204,6 @@
     <string name="notice_crypto_error_unknown_inbound_session_id">Thiết bị của người gửi chưa gửi cho chúng tôi mã khoá cho tin nhắn này.</string>
     <string name="notice_crypto_unable_to_decrypt">** Không thể giải mã: %s **</string>
     <string name="notice_power_level_diff">%1$s từ %2$s thành %3$s</string>
-    <string name="power_level_custom_no_value">Tuỳ chỉnh</string>
-    <string name="power_level_custom">Tuỳ chỉnh (%1$d)</string>
     <string name="power_level_default">Mặc định</string>
     <string name="power_level_moderator">Người điều hành</string>
     <string name="power_level_admin">Quản trị viên</string>
@@ -1614,13 +1612,11 @@
     <string name="rendering_event_error_type_of_event_not_handled">${app_name} không xử lý các sự kiện thuộc loại \'%1$s\'</string>
     <string name="room_member_jump_to_read_receipt">Nhảy để đọc biên nhận</string>
     <string name="room_member_open_or_create_dm">Tin nhắn trực tiếp</string>
-    <string name="room_member_power_level_custom_in">Tùy chỉnh (%1$d) trong %2$s</string>
     <string name="room_member_power_level_default_in">Mặc định trong %1$s</string>
     <string name="room_member_power_level_moderator_in">Người điều hành trong %1$s</string>
     <string name="room_member_power_level_admin_in">Quản trị viên trong %1$s</string>
     <string name="room_member_power_level_users">Người dùng</string>
     <string name="room_member_power_level_invites">Mời</string>
-    <string name="room_member_power_level_custom">Tùy chọn</string>
     <string name="room_member_power_level_moderators">Điều hành viên</string>
     <string name="room_member_power_level_admins">Quản trị viên</string>
     <string name="room_profile_leaving_room">Đang rời phòng…</string>

--- a/library/ui-strings/src/main/res/values-zh-rCN/strings.xml
+++ b/library/ui-strings/src/main/res/values-zh-rCN/strings.xml
@@ -124,8 +124,6 @@
     <string name="power_level_admin">管理员</string>
     <string name="power_level_moderator">协管员</string>
     <string name="power_level_default">默认</string>
-    <string name="power_level_custom">自定义（%1$d）</string>
-    <string name="power_level_custom_no_value">自定义</string>
     <string name="notice_power_level_changed_by_you">你更改了 %1$s 的权限等级。</string>
     <string name="notice_power_level_changed">%1$s 更改了 %2$s 的权限等级。</string>
     <string name="notice_power_level_diff">%1$s 从 %2$s 到 %3$s</string>
@@ -1268,13 +1266,11 @@
     <string name="room_profile_leaving_room">正在离开房间……</string>
     <string name="room_member_power_level_admins">管理员</string>
     <string name="room_member_power_level_moderators">协管员</string>
-    <string name="room_member_power_level_custom">自定义</string>
     <string name="room_member_power_level_invites">邀请</string>
     <string name="room_member_power_level_users">用户</string>
     <string name="room_member_power_level_admin_in">%1$s里的管理员</string>
     <string name="room_member_power_level_moderator_in">%1$s里的协管员</string>
     <string name="room_member_power_level_default_in">%1$s里的默认</string>
-    <string name="room_member_power_level_custom_in">%2$s里的自定义（%1$d）</string>
     <string name="rendering_event_error_type_of_event_not_handled">${app_name} 无法处理类型为 \'%1$s\' 的事件</string>
     <string name="rendering_event_error_exception">${app_name} 在呈现 ID 为“%1$s”的事件内容时遇到问题</string>
     <string name="unignore">取消忽略</string>

--- a/library/ui-strings/src/main/res/values-zh-rTW/strings.xml
+++ b/library/ui-strings/src/main/res/values-zh-rTW/strings.xml
@@ -124,8 +124,6 @@
     <string name="power_level_admin">管理員</string>
     <string name="power_level_moderator">版主</string>
     <string name="power_level_default">預設</string>
-    <string name="power_level_custom">自訂（%1$d）</string>
-    <string name="power_level_custom_no_value">自訂</string>
     <string name="notice_power_level_changed_by_you">您已變更 %1$s 的權限等級。</string>
     <string name="notice_power_level_changed">%1$s 已變更 %2$s 的權限等級。</string>
     <string name="notice_power_level_diff">%1$s 的權限等級從 %2$s 調整為 %3$s</string>
@@ -1223,12 +1221,10 @@
     <string name="room_profile_leaving_room">正在離開聊天室…</string>
     <string name="room_member_power_level_admins">管理員</string>
     <string name="room_member_power_level_moderators">版主</string>
-    <string name="room_member_power_level_custom">自訂</string>
     <string name="room_member_power_level_invites">邀請</string>
     <string name="room_member_power_level_users">使用者</string>
     <string name="room_member_power_level_admin_in">%1$s 中的管理員</string>
     <string name="room_member_power_level_moderator_in">%1$s 中的版主</string>
-    <string name="room_member_power_level_custom_in">自訂 %2$s 中的（%1$d）</string>
     <string name="room_member_jump_to_read_receipt">跳至讀取回條</string>
     <string name="rendering_event_error_type_of_event_not_handled">${app_name} 無法處理類型為「%1$s」的事件</string>
     <string name="rendering_event_error_exception">${app_name} 在渲染 ID 為「%1$s」的事件內容時遇到問題</string>

--- a/library/ui-strings/src/main/res/values/strings.xml
+++ b/library/ui-strings/src/main/res/values/strings.xml
@@ -124,8 +124,6 @@
     <string name="power_level_admin">Admin</string>
     <string name="power_level_moderator">Moderator</string>
     <string name="power_level_default">Default</string>
-    <string name="power_level_custom">Custom (%1$d)</string>
-    <string name="power_level_custom_no_value">Custom</string>
 
     <!-- parameter will be a comma separated list of values of notice_power_level_diff -->
     <string name="notice_power_level_changed_by_you">You changed the power level of %1$s.</string>
@@ -2381,7 +2379,6 @@
 
     <string name="room_member_power_level_admins">Admins</string>
     <string name="room_member_power_level_moderators">Moderators</string>
-    <string name="room_member_power_level_custom">Custom</string>
     <string name="room_member_power_level_invites">Invites</string>
     <string name="room_member_power_level_users">Users</string>
 
@@ -2389,7 +2386,6 @@
     <string name="room_member_power_level_admin_in">Admin in %1$s</string>
     <string name="room_member_power_level_moderator_in">Moderator in %1$s</string>
     <string name="room_member_power_level_default_in">Default in %1$s</string>
-    <string name="room_member_power_level_custom_in">Custom (%1$d) in %2$s</string>
 
     <string name="room_member_open_or_create_dm">Direct message</string>
     <string name="room_member_jump_to_read_receipt">Jump to read receipt</string>

--- a/tools/jitsi/build_jitsi_libs.sh
+++ b/tools/jitsi/build_jitsi_libs.sh
@@ -26,7 +26,7 @@ export LIBRE_BUILD=true
 cd jitsi-meet
 
 # Get the latest version from the changelog: https://github.com/jitsi/jitsi-meet-release-notes/blob/master/CHANGELOG-MOBILE-SDKS.md
-git checkout mobile-sdk-10.2.0
+git checkout mobile-sdk-11.4.0
 
 echo
 echo "##################################################"

--- a/vector-app/src/androidTest/java/im/vector/app/ui/robot/RoomSettingsRobot.kt
+++ b/vector-app/src/androidTest/java/im/vector/app/ui/robot/RoomSettingsRobot.kt
@@ -7,6 +7,7 @@
 
 package im.vector.app.ui.robot
 
+import android.annotation.SuppressLint
 import androidx.test.espresso.Espresso.pressBack
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.matcher.ViewMatchers.withId
@@ -109,6 +110,7 @@ class RoomSettingsRobot {
     private fun navigateToInvite() {
         assertDisplayed(R.id.inviteUsersButton)
         clickOn(R.id.inviteUsersButton)
+        @SuppressLint("CheckResult")
         ViewActions.closeSoftKeyboard()
         pressBack()
     }

--- a/vector-app/src/main/AndroidManifest.xml
+++ b/vector-app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-sdk tools:overrideLibrary="com.sayem.keepawake,com.splashview,com.facebook.react,com.facebook.hermes" />
+
     <application
         android:name="im.vector.app.VectorApplication"
         android:allowBackup="false"

--- a/vector-app/src/main/AndroidManifest.xml
+++ b/vector-app/src/main/AndroidManifest.xml
@@ -2,8 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-sdk tools:overrideLibrary="com.sayem.keepawake,com.splashview,com.facebook.react,com.facebook.hermes" />
-
     <application
         android:name="im.vector.app.VectorApplication"
         android:allowBackup="false"

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -250,7 +250,7 @@ dependencies {
     implementation "androidx.emoji2:emoji2:1.3.0"
 
     // Jitsi
-    api('org.jitsi.react:jitsi-meet-sdk:10.2.0') {
+    api('org.jitsi.react:jitsi-meet-sdk:11.4.0') {
         exclude group: 'com.google.firebase'
         exclude group: 'com.google.android.gms'
         exclude group: 'com.android.installreferrer'

--- a/vector/src/main/AndroidManifest.xml
+++ b/vector/src/main/AndroidManifest.xml
@@ -53,8 +53,8 @@
     <!-- For ScreenCaptureAndroidService -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
 
-    <!-- Jitsi SDK is now API23+ -->
-    <uses-sdk tools:overrideLibrary="com.swmansion.gesturehandler,org.jitsi.meet.sdk,com.oney.WebRTCModule,com.learnium.RNDeviceInfo,com.reactnativecommunity.asyncstorage,com.ocetnik.timer,com.calendarevents,com.reactnativecommunity.netinfo,com.kevinresol.react_native_default_preference,com.rnimmersive,com.rnimmersivemode,com.corbt.keepawake,com.BV.LinearGradient,com.horcrux.svg,com.oblador.performance,com.reactnativecommunity.slider,com.brentvatne.react,com.reactnativecommunity.clipboard,com.swmansion.gesturehandler.react,org.linusu,org.reactnative.maskedview,com.reactnativepagerview,com.swmansion.reanimated,com.th3rdwave.safeareacontext,com.swmansion.rnscreens,org.devio.rn.splashscreen,com.reactnativecommunity.webview,org.wonday.orientation" />
+    <!-- Jitsi SDK is now API26+ -->
+    <uses-sdk tools:overrideLibrary="com.swmansion.gesturehandler,org.jitsi.meet.sdk,com.oney.WebRTCModule,com.learnium.RNDeviceInfo,com.reactnativecommunity.asyncstorage,com.ocetnik.timer,com.calendarevents,com.reactnativecommunity.netinfo,com.kevinresol.react_native_default_preference,com.rnimmersive,com.rnimmersivemode,com.corbt.keepawake,com.BV.LinearGradient,com.horcrux.svg,com.oblador.performance,com.reactnativecommunity.slider,com.brentvatne.react,com.reactnativecommunity.clipboard,com.swmansion.gesturehandler.react,org.linusu,org.reactnative.maskedview,com.reactnativepagerview,com.swmansion.reanimated,com.th3rdwave.safeareacontext,com.swmansion.rnscreens,org.devio.rn.splashscreen,com.reactnativecommunity.webview,org.wonday.orientation,com.sayem.keepawake,com.splashview,com.facebook.react,com.facebook.hermes" />
 
     <!-- For MicrophoneAccessService -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />

--- a/vector/src/main/java/im/vector/app/features/call/conference/VectorJitsiActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/call/conference/VectorJitsiActivity.kt
@@ -229,7 +229,7 @@ class VectorJitsiActivity : VectorBaseActivity<ActivityJitsiBinding>(), JitsiMee
         super.onNewIntent(intent)
     }
 
-    override fun requestPermissions(permissions: Array<out String>?, requestCode: Int, listener: PermissionListener?) {
+    override fun requestPermissions(permissions: Array<String>, requestCode: Int, listener: PermissionListener?) {
         JitsiMeetActivityDelegate.requestPermissions(this, permissions, requestCode, listener)
     }
 

--- a/vector/src/main/java/im/vector/app/features/navigation/DefaultNavigator.kt
+++ b/vector/src/main/java/im/vector/app/features/navigation/DefaultNavigator.kt
@@ -446,8 +446,8 @@ class DefaultNavigator @Inject constructor(
 
     override fun openRoomWidget(context: Context, roomId: String, widget: Widget, options: Map<String, Any>?) {
         if (widget.type is WidgetType.Jitsi) {
-            // Jitsi SDK is now for API 24+
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+            // Jitsi SDK is now for API 26+
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
                 MaterialAlertDialogBuilder(context)
                         .setTitle(CommonStrings.dialog_title_error)
                         .setMessage(CommonStrings.error_jitsi_not_supported_on_old_device)


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

- Bumps the Jitsi library to a new version built with the required changes.
- Bumps the SDK check for Jitsi from `24` to `26`.

## Motivation and context

This is a Jitsi version upgrade to make Element Android compatible with the 16KB page size alignment restriction added by Google on new app versions.

Fixes https://github.com/element-hq/element-android/issues/9041.

## Tests

Make some calls, check everything works.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14, 15

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/element-hq/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
