### PR TITLE
Upgrade io.element.android:opusencoder to 1.1.2. Part of #9086

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -95,7 +95,7 @@ ext.libs = [
                 'hiltCompiler'            : "com.google.dagger:hilt-compiler:$dagger"
         ],
         element     : [
-                'opusencoder'             : "io.element.android:opusencoder:1.1.0",
+                'opusencoder'             : "io.element.android:opusencoder:1.1.2",
                 'wysiwyg'                 : "io.element.android:wysiwyg:2.38.2"
         ],
         squareup    : [


### PR DESCRIPTION
Upgrade io.element.android:opusencoder to 1.1.2.

Part of https://github.com/element-hq/element-android/issues/9086