### PR TITLE
Fixes Russian video call string typos

### DIFF
--- a/library/ui-strings/src/main/res/values-ru/strings.xml
+++ b/library/ui-strings/src/main/res/values-ru/strings.xml
@@ -2214,11 +2214,11 @@
         <item quantity="other">%1$d активных вызовов ·</item>
     </plurals>
     <string name="call_tile_no_answer">Нет ответа</string>
-    <string name="call_tile_video_missed">Пропущенный выдеовызов</string>
+    <string name="call_tile_video_missed">Пропущенный видеовызов</string>
     <string name="call_tile_voice_missed">Пропущенный голосовой вызов</string>
     <string name="call_tile_video_declined">Видеовызов отклонен</string>
     <string name="call_tile_voice_declined">Голосовой вызов отклонен</string>
-    <string name="call_tile_video_call_has_ended">Выдеовызов завершен • %1$s</string>
+    <string name="call_tile_video_call_has_ended">Видеовызов завершен • %1$s</string>
     <string name="call_tile_voice_call_has_ended">Голосовой вызов завершен • %1$s</string>
     <string name="call_tile_video_active">Активный видеовызов</string>
     <string name="call_tile_voice_active">Активный голосовой вызов</string>


### PR DESCRIPTION
Corrects spelling errors for "video call" related messages in Russian UI strings to improve accuracy.

## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Fixed spelling errors in several Russian UI strings related to "video call" messages.

## Motivation and context

Some Russian translations for video call related messages contained spelling mistakes.
This PR corrects them to improve translation accuracy and consistency in the UI.

## Screenshots / GIFs

N/A (no UI changes)

## Tests

- Verified the corrected strings in the Russian localization files.
- Ensured the project builds successfully after the changes.

## Tested devices

- [ ] Physical
- [ ] Emulator

## Checklist

- [x] Pull request is based on the develop branch
- [x] You've made a self review of your PR
