### PR TITLE
#8917 Fix "Cannot find secrets in storage" error on Reset Everything

### DIFF
--- a/changelog.d/8917.bugfix
+++ b/changelog.d/8917.bugfix
@@ -1,0 +1,1 @@
+Fix "Cannot find secrets in storage" error when using "Reset everything" to reset verification keys. ([#8917](https://github.com/element-hq/element-android/issues/8917))

--- a/vector/src/main/java/im/vector/app/features/crypto/quads/SharedSecureStorageViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/quads/SharedSecureStorageViewModel.kt
@@ -93,7 +93,7 @@ class SharedSecureStorageViewModel @AssistedInject constructor(
         setState {
             copy(userId = session.myUserId)
         }
-        if (initialState.requestType is RequestType.ReadSecrets) {
+        if (initialState.requestType is RequestType.ReadSecrets && initialState.step != SharedSecureStorageViewState.Step.ResetAll) {
             val integrityResult =
                     session.sharedSecretStorageService().checkShouldBeAbleToAccessSecrets(initialState.requestType.secretsName, initialState.keyId)
             if (integrityResult !is IntegrityResult.Success) {

--- a/vector/src/test/java/im/vector/app/features/crypto/quads/SharedSecureStorageViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/crypto/quads/SharedSecureStorageViewModelTest.kt
@@ -146,7 +146,29 @@ class SharedSecureStorageViewModelTest {
                 .finish()
     }
 
-    private fun createViewModel(): SharedSecureStorageViewModel {
+    @Test
+    fun `given step is ResetAll then does not check secret storage integrity`() = runTest {
+        val resetAllArgs = SharedSecureStorageActivity.Args(
+                keyId = null,
+                requestedSecrets = emptyList(),
+                resultKeyStoreAlias = "alias",
+                currentStep = SharedSecureStorageViewState.Step.ResetAll
+        )
+
+        val viewModel = createViewModel(resetAllArgs)
+
+        viewModel
+                .test()
+                .assertState(aViewState(
+                        hasPassphrase = true,
+                        step = SharedSecureStorageViewState.Step.ResetAll,
+                        args = resetAllArgs
+                ))
+                .assertNoEvents()
+                .finish()
+    }
+
+    private fun createViewModel(args: SharedSecureStorageActivity.Args = this.args): SharedSecureStorageViewModel {
         return SharedSecureStorageViewModel(
                 SharedSecureStorageViewState(args),
                 stringProvider.instance,
@@ -155,7 +177,11 @@ class SharedSecureStorageViewModelTest {
         )
     }
 
-    private fun aViewState(hasPassphrase: Boolean, step: SharedSecureStorageViewState.Step) = SharedSecureStorageViewState(args).copy(
+    private fun aViewState(
+            hasPassphrase: Boolean,
+            step: SharedSecureStorageViewState.Step,
+            args: SharedSecureStorageActivity.Args = this.args,
+    ) = SharedSecureStorageViewState(args).copy(
             ready = true,
             hasPassphrase = hasPassphrase,
             checkingSSSSAction = Uninitialized,


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Skip the SSSS integrity check when the user is in the "Reset everything" flow. The integrity check at `SharedSecureStorageViewModel` init validates that secrets exist in storage before proceeding but the "Reset everything" flow is specifically for when the user has lost access to their secrets. This creates a state where the reset fails because the very secrets the user wants to reset cannot be found.

The fix adds the same `ResetAll` step guard that already exists below for the key lookup (line 109), making the two checks consistent.

## Motivation and context

Here is the issue this is fixing: https://github.com/element-hq/element-android/issues/8917

## Tests

- Step 1: Fresh account or account without SSSS setup
- Step 2: Trigger self-verification flow
- Step 3: Tap "Forgot or lost all recovery options? Reset everything"
- Step 4: Verify the reset confirmation screen appears instead of the error dialog

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/element-hq/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)

Signed-off-by: Christian Rowlands <craxiomdev [at] gmail.com>