### PR TITLE
Hide "Verify this device" banner (#9130)

### DIFF
--- a/changelog.d/9130.misc
+++ b/changelog.d/9130.misc
@@ -1,0 +1,1 @@
+Temporary hide "Verify this device" banner.

--- a/vector/src/main/java/im/vector/app/features/home/HomeDetailViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeDetailViewState.kt
@@ -38,6 +38,9 @@ data class HomeDetailViewState(
         val isSessionVerified: Boolean = true,
 ) : MavericksState {
     val showDialPadTab = forceDialPadTab || pstnSupportFlag
+
+    // Temporarily disabled until we have a way to reset from the verification screen.
+    val showVerifyDeviceBanner = false // !isSessionVerified
 }
 
 sealed class HomeTab(@StringRes val titleRes: Int) {

--- a/vector/src/main/java/im/vector/app/features/home/NewHomeDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/NewHomeDetailFragment.kt
@@ -14,7 +14,6 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
 import com.airbnb.mvrx.activityViewModel
@@ -387,7 +386,7 @@ class NewHomeDetailFragment :
                 it.pushCounter,
                 vectorPreferences.developerShowDebugInfo()
         )
-        views.homeVerifyDevice.isGone = it.isSessionVerified
+        views.homeVerifyDevice.isVisible = it.showVerifyDeviceBanner
         refreshAvatar()
         hasUnreadRooms = it.hasUnreadMessages
     }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [X] Other :

## Content
Hide "Verify this device" banner
<!-- Describe shortly what has been changed -->

## Motivation and context
Close https://github.com/element-hq/element-android/issues/9130
<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/element-hq/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
