### PR TITLE
Add fingerprint of Element X nightly builds.

### DIFF
--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -88,6 +88,25 @@ android {
                             ")",
             )
         }
+        nightly {
+            matchingFallbacks = ['release']
+            buildConfigField(
+                    "java.util.List<im.vector.app.features.importer.ApplicationFingerprint>",
+                    "ALLOWED_APP_SIGNATURES",
+                    "java.util.Arrays.asList(\n" +
+                            // Element
+                            "new im.vector.app.features.importer.ApplicationFingerprint(\n" +
+                            "\"io.element.android.x.nightly\",\n" +
+                            "java.util.Arrays.asList(\"CA:D3:85:16:84:3A:05:CC:EB:00:AB:7B:D3:80:0F:01:BA:8F:E0:4B:38:86:F3:97:D8:F7:9A:1B:C4:54:E4:0F\")\n" +
+                            "),\n" +
+                            // Element Pro
+                            "new im.vector.app.features.importer.ApplicationFingerprint(\n" +
+                            "\"io.element.enterprise.nightly\",\n" +
+                            "java.util.Arrays.asList(\"CA:D3:85:16:84:3A:05:CC:EB:00:AB:7B:D3:80:0F:01:BA:8F:E0:4B:38:86:F3:97:D8:F7:9A:1B:C4:54:E4:0F\")\n" +
+                            ")\n" +
+                            ")",
+            )
+        }
         release {
             buildConfigField(
                     "java.util.List<im.vector.app.features.importer.ApplicationFingerprint>",


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
We want to test migration to Element X on the nightly builds of the application, so Element Classic nightly build has to know the fingerprint of Element X nightly build.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Ensure Element X nightly can sign in using Element Classic nightly.

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/element-hq/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
