### PR TITLE
Fix UCrop screen overlapping the system bars on Android 15+ (#9084)

### DIFF
--- a/changelog.d/9084.bugfix
+++ b/changelog.d/9084.bugfix
@@ -1,0 +1,1 @@
+Fix the avatar / image cropping screen on Android 15+: the toolbar save button and the bottom rotate / scale controls are no longer hidden behind the system status bar and 3-button navigation bar. ([#9084](https://github.com/element-hq/element-android/issues/9084))

--- a/library/ui-styles/src/main/res/values-v35/theme_ucrop.xml
+++ b/library/ui-styles/src/main/res/values-v35/theme_ucrop.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+
+    <!--
+        Android 15 (API 35) forces every window to be edge-to-edge when the app
+        targets SDK 35+. UCrop 2.2.8 does not handle WindowInsets, which causes
+        its title bar (close / save) to be hidden behind the status bar and the
+        rotate / scale controls to be hidden behind 3-button navigation.
+
+        windowOptOutEdgeToEdgeEnforcement is the official escape hatch documented
+        for legacy screens that have not yet been migrated to insets-aware layout.
+        It is honoured on API 35 only; on API 36+ we will need to either upgrade
+        UCrop or override its layouts to consume insets directly.
+
+        Tracks https://github.com/element-hq/element-android/issues/9084
+    -->
+    <style name="Theme.Vector.UCrop" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="android:windowOptOutEdgeToEdgeEnforcement" tools:targetApi="35">true</item>
+    </style>
+
+</resources>

--- a/library/ui-styles/src/main/res/values/theme_ucrop.xml
+++ b/library/ui-styles/src/main/res/values/theme_ucrop.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!--
+        Theme applied to com.yalantis.ucrop.UCropActivity.
+
+        UCrop 2.2.8 (the version pinned in :vector) does not consume window insets,
+        so its toolbar and bottom controls are drawn under the system bars when the
+        platform enforces edge-to-edge layout (Android 15 / API 35+).
+
+        On older API levels there is nothing to do here: the system bars are opaque
+        and the activity already lays out within them. The v35 override of this
+        theme opts the activity out of edge-to-edge enforcement so the toolbar's
+        save button and the bottom rotate / scale controls remain reachable.
+
+        AppCompat.Light.NoActionBar matches the parent declared by uCrop's own
+        manifest entry, so the activity continues to render its custom toolbar.
+    -->
+    <style name="Theme.Vector.UCrop" parent="Theme.AppCompat.Light.NoActionBar" />
+
+</resources>

--- a/vector/src/main/AndroidManifest.xml
+++ b/vector/src/main/AndroidManifest.xml
@@ -293,7 +293,8 @@
         <activity android:name=".features.crypto.quads.SharedSecureStorageActivity" />
         <activity
             android:name="com.yalantis.ucrop.UCropActivity"
-            android:screenOrientation="portrait" />
+            android:screenOrientation="portrait"
+            android:theme="@style/Theme.Vector.UCrop" />
         <activity
             android:name=".features.attachments.preview.AttachmentsPreviewActivity"
             android:theme="@style/Theme.Vector.Black.AttachmentsPreview" />


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Apply a dedicated theme to `com.yalantis.ucrop.UCropActivity` that, on **API 35 only**, opts the activity out of forced edge-to-edge layout via `android:windowOptOutEdgeToEdgeEnforcement="true"` — the [official escape hatch](https://developer.android.com/reference/android/R.attr#windowOptOutEdgeToEdgeEnforcement) documented for legacy screens that have not yet been migrated to insets-aware layouts.

Files changed:

- `library/ui-styles/src/main/res/values/theme_ucrop.xml` — base `Theme.Vector.UCrop`, just inheriting `Theme.AppCompat.Light.NoActionBar` (the parent uCrop's own manifest declares). No-op on API < 35.
- `library/ui-styles/src/main/res/values-v35/theme_ucrop.xml` — overrides the theme on API 35 to add `android:windowOptOutEdgeToEdgeEnforcement="true"`.
- `vector/src/main/AndroidManifest.xml` — applies `android:theme="@style/Theme.Vector.UCrop"` to the existing `UCropActivity` entry.
- `changelog.d/9084.bugfix`.

The follow-up plan is documented in the v35 theme's XML comment: when the project bumps to `targetSdk = 36` (where `windowOptOutEdgeToEdgeEnforcement` is no longer honoured), uCrop will need to be upgraded or its layouts overridden in `vector/src/main/res/layout/` to consume insets directly. Doing that today is invasive and out of scope for a bug-fix; this change unblocks affected users right now without touching any other screen.

## Motivation and context

Closes #9084.

Since the app targets SDK 35, Android 15 forces edge-to-edge layout for every window. UCrop 2.2.8 — the third-party library backing the avatar / image cropping screen invoked from `GalleryOrCameraDialogHelper`, `AttachmentsPreviewFragment` and `UCropHelper` — does not consume `WindowInsets`. The result on Android 15:

- The toolbar (containing the **✓ save** checkmark) is drawn **under the status bar**. On many devices the save gesture is captured by the status bar pull-down instead, so users cannot save their new avatar at all (see the user reports on #9084 from Pixel 8 Pro / Pixel 6a / Pixel 7a / Moto Edge 60 Pro).
- The bottom rotate / scale controls are drawn **under the 3-button navigation bar**, so they are partially obscured and hard to hit.

Both problems are visible in the original report's screenshot and in [@stringlapse's annotated screenshot](https://github.com/element-hq/element-android/issues/9084#issuecomment-...) on the same issue. They reproduce 100% on any device running Android 15 with 3-button navigation; gesture navigation hides the issue at the bottom but the save button at the top is still affected.

`UCropHelper.kt` already calls `setStatusBarColor(...)` and `setToolbarColor(...)`, so once the activity's window is no longer forced edge-to-edge those colours behave correctly and the toolbar / bottom bar lay out within the safe area. No code changes are required in `UCropHelper`.

## Screenshots / GIFs

| Before (Element Classic 1.6.54, Android 15, 3-button nav) | After |
|-|-|
| Title row with the `X` close button and `✓` save check are hidden behind the status bar (clock / battery overlap them); bottom rotate / scale tabs are hidden behind the home / back / recents buttons. See screenshots on #9084. | Toolbar and bottom controls render fully within the safe area; save button is tappable. |

## Tests

- Step 1: Open Element Classic on a device or emulator running Android 15 (API 35). Sign in.
- Step 2: Tap your avatar → Settings → tap your account name → tap your current profile picture → choose **Take photo** or **Choose from gallery**.
- Step 3: After the picture is captured / picked, the **Rotate and crop** screen opens.
- Step 4: Verify the title bar (close `X`, "Rotate and crop" title, save `✓`) is fully below the status bar.
- Step 5: Verify the bottom rotate / scale tabs sit fully above the navigation bar with both gesture navigation and 3-button navigation.
- Step 6: Tap save and confirm the new avatar is uploaded.
- Step 7: Repeat on Android 14 (API 34) to confirm no regression — the screen should look identical to current behaviour.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

> [!NOTE]
> Unable to test on a physical device or emulator from the contributor's environment. Reviewer please verify on a real Android 15 device with 3-button navigation. The change is XML-only (a new theme + one manifest attribute) and is the standard documented escape hatch for this exact scenario, so the risk of regression on other API levels is minimal.

## Checklist

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#accessibility — the fix actually *improves* accessibility, since previously the save button could not be activated by touch on affected devices.
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes — see #9084 for "before" screenshots from multiple users
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [x] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/element-hq/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73) — N/A, no screen flow changes.