### PR TITLE
Fix #8894 bug, crashing while listening to notifications

### DIFF
--- a/vector-app/src/fdroid/java/im/vector/app/fdroid/service/GuardAndroidService.kt
+++ b/vector-app/src/fdroid/java/im/vector/app/fdroid/service/GuardAndroidService.kt
@@ -11,6 +11,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import im.vector.app.core.services.VectorAndroidService
 import im.vector.app.features.notifications.NotificationUtils
 import im.vector.lib.strings.CommonStrings
+import timber.log.Timber
 import javax.inject.Inject
 
 /**
@@ -27,7 +28,14 @@ class GuardAndroidService : VectorAndroidService() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         val notificationSubtitleRes = CommonStrings.notification_listening_for_notifications
         val notification = notificationUtils.buildForegroundServiceNotification(notificationSubtitleRes, false)
-        startForeground(NotificationUtils.NOTIFICATION_ID_FOREGROUND_SERVICE, notification)
+        try {
+            startForeground(NotificationUtils.NOTIFICATION_ID_FOREGROUND_SERVICE, notification)
+        } catch (e: Exception) {
+            Timber.e("## Sync: Failed to start GuardAndroidService as foreground service: ${e.message}")
+            // Stop the service if we can't start it as foreground
+            stopSelf()
+            return START_NOT_STICKY
+        }
         return START_STICKY
     }
 }


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Captures exceptions and logs them coming from the foreground notification listener service. 

## Motivation and context

The foreground notification listener service eventually times out, as Android 12+ does not allow applications running in the foreground indefinitely. The service than gets interrupted and runs into an exception, which never gets properly caught and so it ends up with the application crashing.

While this change doesn't fix the underlying issue, that the foreground notification listener service cannot run any longer, at least it doesn't crash the application.

I do wonder, however, if the whole foreground notification listener is not really viable in this form.

## Tests

1. Start the app
2. Set the Settings > Notifications > Background Sync Mode to Optimised for real time
3. Wait:

```sh
#!/system/bin/sh
adb shell input KEYCODE_HOME && \
sleep 5400
```

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/element-hq/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
