### PR TITLE
Translations for the "verify device before October" banner.

### DIFF
--- a/changelog.d/9141.misc
+++ b/changelog.d/9141.misc
@@ -1,0 +1,1 @@
+Show "Verify this device" banner on un-verified devices.

--- a/library/ui-strings/src/main/res/values-de/strings.xml
+++ b/library/ui-strings/src/main/res/values-de/strings.xml
@@ -1290,6 +1290,8 @@
         <item quantity="other">%d aktive Sitzungen</item>
     </plurals>
     <string name="crosssigning_verify_this_session">Verifiziere dieses Gerät</string>
+    <string name="verify_this_session_content">Ab Oktober 2026 können unverifizierte Geräte keine Nachrichten mehr senden und empfangen.</string>
+    <string name="verify_now">Jetzt verifizieren</string>
     <string name="verification_open_other_to_verify">Nutze eine vorhandene Sitzung um diese Sitzung zu verifizieren und ihr Zugriff auf verschlüsselte Nachrichten zu gewähren.</string>
     <string name="verification_profile_verify">Verifizieren</string>
     <string name="verification_profile_verified">Verifiziert</string>

--- a/library/ui-strings/src/main/res/values-fr/strings.xml
+++ b/library/ui-strings/src/main/res/values-fr/strings.xml
@@ -1265,6 +1265,8 @@
         <item quantity="other">%d sessions actives</item>
     </plurals>
     <string name="crosssigning_verify_this_session">Vérifier cet appareil</string>
+    <string name="verify_this_session_content">À partir d’octobre 2026, les appareils non vérifiés ne pourront plus envoyer ni recevoir de messages</string>
+    <string name="verify_now">Vérifier maintenant</string>
     <string name="verification_open_other_to_verify">Utilisez une session existante pour vérifier celle-ci, ce qui lui permettra d’avoir accès aux messages chiffrés.</string>
     <string name="verification_profile_verify">Vérifier</string>
     <string name="verification_profile_verified">Vérifié</string>

--- a/library/ui-strings/src/main/res/values-hr/strings.xml
+++ b/library/ui-strings/src/main/res/values-hr/strings.xml
@@ -844,4 +844,8 @@
     <string name="notice_room_created_by_you">Ti si kreirao sobu</string>
     <string name="notice_room_created">%1$s je kreirao sobu</string>
     <string name="notice_room_invite_no_invitee_by_you">Tvoja pozivnica</string>
+    <string name="crosssigning_verify_this_session">Verificirajte ovaj uređaj</string>
+    <string name="verify_this_session_content">Od listopada 2026. neverificirani uređaji više neće moći slati i primati poruke.</string>
+    <string name="action_learn_more">Saznajte više</string>
+    <string name="verify_now">Verificiraj sada</string>
 </resources>

--- a/library/ui-strings/src/main/res/values-nl/strings.xml
+++ b/library/ui-strings/src/main/res/values-nl/strings.xml
@@ -1991,6 +1991,8 @@
     <string name="room_member_profile_failed_to_get_devices">Kan geen sessies ophalen</string>
     <string name="verification_open_other_to_verify">Gebruik een bestaande sessie om deze te verifiëren en deze toegang te verlenen tot versleutelde berichten.</string>
     <string name="crosssigning_verify_this_session">Verifieer dit apparaat</string>
+    <string name="verify_this_session_content">Vanaf oktober 2026 kunnen niet-geverifieerde apparaten geen berichten meer verzenden en ontvangen.</string>
+    <string name="verify_now">Nu verifiëren</string>
     <plurals name="settings_active_sessions_count">
         <item quantity="one">%d actieve sessie</item>
         <item quantity="other">%d actieve sessies</item>

--- a/library/ui-strings/src/main/res/values-pl/strings.xml
+++ b/library/ui-strings/src/main/res/values-pl/strings.xml
@@ -1126,6 +1126,8 @@
         <item quantity="other">%d aktywnych sesji</item>
     </plurals>
     <string name="crosssigning_verify_this_session">Weryfikuj to urządzenie</string>
+    <string name="verify_this_session_content">Od października 2026 r. niezweryfikowane urządzenia nie będą mogły wysyłać ani odbierać wiadomości.</string>
+    <string name="verify_now">Zweryfikuj teraz</string>
     <string name="verification_open_other_to_verify">Otwórz obecną sesję i użyj jej do zweryfikowania obecnej, przyznając jej dostęp do zaszyfrowanych wiadomości.</string>
     <string name="verification_profile_verify">Zweryfkuj</string>
     <string name="verification_profile_verified">Zweryfikowano</string>

--- a/library/ui-strings/src/main/res/values/strings.xml
+++ b/library/ui-strings/src/main/res/values/strings.xml
@@ -2717,7 +2717,7 @@
     <string name="review_unverified_sessions_description">Review to ensure your account is safe</string>
     <!-- Argument will be replaced by the other session name (e.g, Desktop, mobile) -->
     <string name="verify_this_session">Verify the new login accessing your account: %1$s</string>
-    <string name="verify_this_session_content">As of April 2026 unverified devices will not be able to send and receive messages.</string>
+    <string name="verify_this_session_content">As of October 2026 unverified devices will not be able to send and receive messages.</string>
     <string name="verify_now">Verify now</string>
 
     <string name="cross_signing_verify_by_text">Manually Verify by Text</string>

--- a/vector/src/main/java/im/vector/app/features/home/HomeDetailViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeDetailViewModel.kt
@@ -61,7 +61,8 @@ class HomeDetailViewModel @AssistedInject constructor(
         private val directRoomHelper: DirectRoomHelper,
         private val spaceStateHandler: SpaceStateHandler,
         private val autoAcceptInvites: AutoAcceptInvites,
-        private val vectorOverrides: VectorOverrides
+        private val vectorOverrides: VectorOverrides,
+        private val showVerifyDeviceBannerChecker: ShowVerifyDeviceBannerChecker,
 ) : VectorViewModel<HomeDetailViewState, HomeDetailAction, HomeDetailViewEvents>(initialState),
         CallProtocolsChecker.Listener {
 
@@ -103,18 +104,20 @@ class HomeDetailViewModel @AssistedInject constructor(
     }
 
     private fun observeCrossSigningState() {
-        session
-                .flow()
-                .liveCrossSigningInfo(session.myUserId)
-                .onEach { info ->
-                    val isVerified = info.getOrNull()?.isTrusted() ?: false
-                    setState {
-                        copy(
-                                isSessionVerified = isVerified,
-                        )
+        if (showVerifyDeviceBannerChecker.canShowVerifyDeviceBanner(session.myUserId)) {
+            session
+                    .flow()
+                    .liveCrossSigningInfo(session.myUserId)
+                    .onEach { info ->
+                        val isVerified = info.getOrNull()?.isTrusted() ?: false
+                        setState {
+                            copy(
+                                    showVerifyDeviceBanner = !isVerified,
+                            )
+                        }
                     }
-                }
-                .launchIn(viewModelScope)
+                    .launchIn(viewModelScope)
+        }
     }
 
     private fun observeDataStore() {

--- a/vector/src/main/java/im/vector/app/features/home/HomeDetailViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeDetailViewState.kt
@@ -39,8 +39,7 @@ data class HomeDetailViewState(
 ) : MavericksState {
     val showDialPadTab = forceDialPadTab || pstnSupportFlag
 
-    // Temporarily disabled until we have a way to reset from the verification screen.
-    val showVerifyDeviceBanner = false // !isSessionVerified
+    val showVerifyDeviceBanner = !isSessionVerified
 }
 
 sealed class HomeTab(@StringRes val titleRes: Int) {

--- a/vector/src/main/java/im/vector/app/features/home/HomeDetailViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeDetailViewState.kt
@@ -34,12 +34,10 @@ data class HomeDetailViewState(
         val pushCounter: Int = 0,
         val pstnSupportFlag: Boolean = false,
         val forceDialPadTab: Boolean = false,
-        // Set to true by default to avoid glitch
-        val isSessionVerified: Boolean = true,
+        // Set to false by default to avoid glitch
+        val showVerifyDeviceBanner: Boolean = false,
 ) : MavericksState {
     val showDialPadTab = forceDialPadTab || pstnSupportFlag
-
-    val showVerifyDeviceBanner = !isSessionVerified
 }
 
 sealed class HomeTab(@StringRes val titleRes: Int) {

--- a/vector/src/main/java/im/vector/app/features/home/ShowVerifyDeviceBannerChecker.kt
+++ b/vector/src/main/java/im/vector/app/features/home/ShowVerifyDeviceBannerChecker.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package im.vector.app.features.home
+
+import org.matrix.android.sdk.api.MatrixPatterns.getServerName
+import java.security.MessageDigest
+import javax.inject.Inject
+
+class ShowVerifyDeviceBannerChecker @Inject constructor() {
+    companion object {
+        private val EXCLUDED_HASHED_DOMAINS = setOf(
+                "9e6d1ca3e739dd3f879b8046af783402a34d247f879dfa1b531edbd56a56c1a6",
+        )
+    }
+
+    @OptIn(ExperimentalStdlibApi::class)
+    fun canShowVerifyDeviceBanner(userId: String): Boolean {
+        val sha256 = MessageDigest.getInstance("SHA-256")
+        val hashedDomain = userId.getServerName()
+                .split(".")
+                .takeLast(2)
+                .joinToString(".")
+                .let { sha256.digest(it.toByteArray()).toHexString() }
+        return hashedDomain !in EXCLUDED_HASHED_DOMAINS
+    }
+}

--- a/vector/src/test/java/im/vector/app/features/home/ShowVerifyDeviceBannerCheckerTest.kt
+++ b/vector/src/test/java/im/vector/app/features/home/ShowVerifyDeviceBannerCheckerTest.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package im.vector.app.features.home
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ShowVerifyDeviceBannerCheckerTest {
+    private val checker = ShowVerifyDeviceBannerChecker()
+
+    @Test
+    fun `should show banner for non excluded domain`() {
+        val userId = "@user:example.com"
+        assertTrue(checker.canShowVerifyDeviceBanner(userId))
+    }
+
+    @Test
+    fun `should show banner for matrix_org users`() {
+        val userId = "@user:matrix.org"
+        assertTrue(checker.canShowVerifyDeviceBanner(userId))
+    }
+}


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other : translations

## Content

Translations added.

## Motivation and context

Help the users in their native language.

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/element-hq/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
