### PR TITLE
Bump Crypto SDK dependency to `v26.05.12`

### DIFF
--- a/matrix-sdk-android/build.gradle
+++ b/matrix-sdk-android/build.gradle
@@ -221,7 +221,7 @@ dependencies {
 
     implementation libs.google.phonenumber
 
-    implementation("org.matrix.rustcomponents:crypto-android:26.1.28")
+    implementation("org.matrix.rustcomponents:crypto-android:26.05.12")
 //    api project(":library:rustCrypto")
 
     testImplementation libs.tests.junit

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/contentscanner/ScanEncryptorUtils.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/contentscanner/ScanEncryptorUtils.kt
@@ -43,12 +43,12 @@ internal object ScanEncryptorUtils {
                 ),
                 v = "v2"
         )
-        return if (publicServerKey != null) {
+        return publicServerKey?.let { serverKey ->
             // Note: fromBase64 can throw Exception
-            val pkEncryption = PkEncryption.fromBase64(key = publicServerKey)
+            val pkEncryption = PkEncryption.fromBase64(key = serverKey)
             val pkMessage = pkEncryption.use {
                 pkEncryption.encrypt(DownloadBody(encryptedInfo).toCanonicalJson())
-            }
+            } ?: error("Encryption failed, the keys used for encryption are not valid")
             DownloadBody(
                     encryptedBody = EncryptedBody(
                             cipherText = pkMessage.ciphertext,
@@ -56,8 +56,6 @@ internal object ScanEncryptorUtils {
                             mac = pkMessage.mac
                     )
             )
-        } else {
-            DownloadBody(encryptedInfo)
-        }
+        } ?: DownloadBody(encryptedInfo)
     }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other :

## Content

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/element-hq/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
