### PR TITLE
Drop allowFileAccessFromFileURLs and allowUniversalAccessFromFileURLs in VectorWebViewActivity and WidgetWebView

### DIFF
--- a/changelog.d/9144.bugfix
+++ b/changelog.d/9144.bugfix
@@ -1,0 +1,1 @@
+Drop allowFileAccessFromFileURLs and allowUniversalAccessFromFileURLs in VectorWebViewActivity and WidgetWebView. Both call sites only load http/https URLs, so the flags are not load-bearing and are CWE-200 sandbox-escape vectors when left on.

--- a/vector/src/main/java/im/vector/app/features/webview/VectorWebViewActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/webview/VectorWebViewActivity.kt
@@ -55,10 +55,14 @@ class VectorWebViewActivity : VectorBaseActivity<ActivityVectorWebViewBinding>()
             // Allow use of Local Storage
             domStorageEnabled = true
 
-            @Suppress("DEPRECATION")
-            allowFileAccessFromFileURLs = true
-            @Suppress("DEPRECATION")
-            allowUniversalAccessFromFileURLs = true
+            // allowFileAccessFromFileURLs and allowUniversalAccessFromFileURLs
+            // only take effect when the main frame is a file:// URL. This
+            // Activity is launched with EXTRA_URL set to an http/https URL
+            // (identity-server terms pages, SSO fallback, etc.), so neither
+            // flag is load-bearing here, and
+            // allowUniversalAccessFromFileURLs in particular is a
+            // CWE-200 sandbox-escape vector if a file:// load ever lands
+            // in this Activity.
 
             displayZoomControls = false
         }

--- a/vector/src/main/java/im/vector/app/features/widgets/webview/WidgetWebView.kt
+++ b/vector/src/main/java/im/vector/app/features/widgets/webview/WidgetWebView.kt
@@ -42,10 +42,11 @@ fun WebView.setupForWidget(activity: Activity,
     // Allow use of Local Storage
     settings.domStorageEnabled = true
 
-    @Suppress("DEPRECATION")
-    settings.allowFileAccessFromFileURLs = true
-    @Suppress("DEPRECATION")
-    settings.allowUniversalAccessFromFileURLs = true
+    // allowFileAccessFromFileURLs and allowUniversalAccessFromFileURLs
+    // only take effect when the main frame is a file:// URL. Widgets are
+    // always served from an https widget URL, so neither flag is
+    // load-bearing here, and allowUniversalAccessFromFileURLs in
+    // particular is a CWE-200 sandbox-escape vector.
 
     settings.displayZoomControls = false
 


### PR DESCRIPTION
Type: Bug fix
Issue: #9144

## Motivation

Two WebView setup paths still toggle the deprecated `allowFileAccessFromFileURLs` and `allowUniversalAccessFromFileURLs` flags even though neither WebView ever loads a `file://` main frame.

### VectorWebViewActivity

Invoked through `VectorWebViewActivity.getIntent(context, url, ...)`. Every call site that builds that intent supplies an http or https URL (identity-server terms pages, SSO fallback, etc.). The two flags only take effect on a `file://` main frame, so they do nothing for the actual launch paths.

### WidgetWebView

Widgets are served from the integration server's https widget URL. Same reasoning applies.

## Content

Drop the `setAllowFileAccessFromFileURLs = true` and `setAllowUniversalAccessFromFileURLs = true` lines in both files. Replace them with a short inline comment recording why neither flag is needed.

`allowUniversalAccessFromFileURLs = true` is the universal-XSS flag from the `WebSettings` javadoc (lets a `file://` page XHR any origin, CWE-200). It is unsafe to leave on as a safety margin if a future code path ever loads a `file://` document into one of these WebViews. The `@Suppress("DEPRECATION")` annotations on the removed lines suggest the deprecation warning was acknowledged but the flags were never re-evaluated.

On pre-API-30 devices both flags default to `true`, so removing the explicit `= true` lines is a tightening on those devices rather than a no-op only on API 30+.

## Provenance

Originally filed against the SchildiChat fork ([SchildiChat/SchildiChat-android#284](https://github.com/SchildiChat/SchildiChat-android/issues/284), [#285](https://github.com/SchildiChat/SchildiChat-android/pull/285)). The maintainer asked me to file it upstream, so this PR is the upstream version.

## Test plan

The change is two lines removed in each file plus a short comment. No other WebView setting touched. Both call paths continue to load their http/https URLs unchanged.

## Checklist

- [x] Changelog file added (`changelog.d/9144.bugfix`)